### PR TITLE
KBV-142 Reference openapi definition from local file

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -3,5 +3,4 @@
 ./gradlew clean buildZip
 sam build -t deploy/template.yaml --config-env dev
 sam validate -t deploy/template.yaml --config-env dev
-aws s3 cp deploy/api.yaml s3://di-ipv-address-cri-api/dev/api.yaml
 sam deploy -t deploy/template.yaml --config-env dev --config-file samconfig.toml --no-fail-on-empty-changeset

--- a/deploy/api.yaml
+++ b/deploy/api.yaml
@@ -1,5 +1,6 @@
 openapi: "3.0.1"
 info:
+  version: "0.1"
   title: "Address Credential Issuer API"
 paths:
   /session:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -70,7 +70,7 @@ Resources:
   AddressSessionTable:
     Type: "AWS::DynamoDB::Table"
     Properties:
-      TableName: "address-session"
+      TableName: !Sub "address-session-${AWS::StackName}"
       BillingMode: "PAY_PER_REQUEST"
       AttributeDefinitions:
         -

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -13,10 +13,6 @@ Parameters:
       - integration
       - prod
     ConstraintDescription: specify dev, staging, integration or prod for environment
-  APIS3BucketName:
-    Type: String
-    Description: The name of the S3 bucket for the api gateway openapi definiiton
-    Default: di-ipv-cri-address-api
 
 Globals:
   Function:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -34,10 +34,14 @@ Resources:
 #      Auth:
 #        DefaultAuthorizer: AWS_IAM
       DefinitionBody:
+        openapi: "3.0.1" # workaround to get `sam validate` to work
+        paths: # workaround to get `sam validate` to work
+          /never-created:
+            options: { } # workaround to get `sam validate` to work
         Fn::Transform:
-          Name: AWS::Include # the api.yaml file needs to be in an s3 bucket for Arn interpolation
+          Name: AWS::Include
           Parameters:
-            Location: s3://di-ipv-address-cri-api/dev/api.yaml
+            Location: './api.yaml'
       OpenApiVersion: 3.0.1
       EndpointConfiguration:
         Type: REGIONAL

--- a/doc/api.puml
+++ b/doc/api.puml
@@ -22,10 +22,11 @@ end box
 core -[#green]> fe : /authorize\n{ jwt }
 activate fe
 
-fe -> api: POST /session\n{ jwt }
+fe -> api: PUT /session\n{ jwt }
 activate api
 api -> api: validate JWT
-api -> api: create & write session
+api -> api: create session
+api -> db: write session
 return session-id
 
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Reference the openapi yaml file from a local file, rather than s3

### What changed

Removed the need to place the openapi yaml in s3, we can refer to it locally.

### Why did it change

Using an S3 bucket makes more moving parts, and I didn't know how to do this previously - props to @jkunle for figuring this out.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-142](https://govukverify.atlassian.net/browse/KBV-142)
