### PR TITLE
[KBV-177] update ssm parameter name

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -59,7 +59,7 @@ Resources:
       Description: "Code Signing for SessionFunction"
       AllowedPublishers:
         SigningProfileVersionArns:
-          - "{{resolve:ssm:/dev/credentialIssuers/kbv/sam/signingProfileVersionArn}}"
+          - "{{resolve:ssm:/dev/credentialIssuers/cri/sam/signingProfileVersionArn}}"
       CodeSigningPolicies:
         UntrustedArtifactOnDeployment: "Enforce"
 


### PR DESCRIPTION

## Proposed changes

### What changed

Update SSM parameter name to bring into line with naming convention updates.

### Why did it change

The parameter name changed due to conventions introduced with the new AWS account.

### Issue tracking
- [KBV-177](https://govukverify.atlassian.net/browse/KBV-177)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

None