### PR TITLE
KBV-177] Update parameter names and deploy config

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,8 +54,8 @@ jobs:
       - name: SAM deploy
         run: |
           sam deploy -t deploy/template.yaml --config-env ${{ env.ENVIRONMENT }} \
-            --config-file samconfig.toml --no-fail-on-empty-changeset \
+            --no-fail-on-empty-changeset --no-confirm-changeset ${{ env.ROLLBACK_ACTION }} \
             --signing-profiles SessionFunction=${{ steps.code_signing.outputs.profile }} \
             --stack-name ${{ env.STACK_NAME }} --s3-bucket di-ipv-cri-lambda-artifact-bucket \
-            --s3-prefix --stack-name ${{ env.STACK_NAME }} --region ${{ env.AWS_REGION }} \
-            --no-confirm-changeset ${{ env.ROLLBACK_ACTION }} --capabilities CAPABILITY_IAM
+            --s3-prefix ${{ env.STACK_NAME }} --region ${{ env.AWS_REGION }} \
+            --capabilities CAPABILITY_IAM

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -59,7 +59,7 @@ Resources:
       Description: "Code Signing for SessionFunction"
       AllowedPublishers:
         SigningProfileVersionArns:
-          - "{{resolve:ssm:/dev/credentialIssuers/kbv/sam/signingProfileVersionArn}}"
+          - "{{resolve:ssm:/dev/credentialIssuers/cri/sam/signingProfileVersionArn}}"
       CodeSigningPolicies:
         UntrustedArtifactOnDeployment: "Enforce"
 


### PR DESCRIPTION
## Proposed changes

### What changed

* Update SSM parameter name to bring into line with naming convention updates.
* Remove erroneous extra region parameter arg from deployment config.

### Why did it change

* The parameter name changed due to conventions introduced with the new AWS account.
* The additional arg caused incorrect s3 prefix to be used.

### Issue tracking
- [KBV-177](https://govukverify.atlassian.net/browse/KBV-177)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

None
