### PR TITLE
[KBV-177] use github environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    environment: di-ipv-cri-dev
     timeout-minutes: 15
     env:
       AWS_REGION: eu-west-2


### PR DESCRIPTION
Update workflow to use the GitHub di-ipv-cri-dev environment

## Proposed changes

### What changed

Deployment workflow updated to use the GitHub di-ipv-cri-dev environment

### Why did it change

So that the deployment will pick up the environment secrets

### Issue tracking

- [KBV-177](https://govukverify.atlassian.net/browse/KBV-177)

## Checklists

### Environment variables or secrets


- [X] No environment variables or secrets were added or changed



### Other considerations

None