### PR TITLE
KBV-233 update dev deployment to be manual

### DIFF
--- a/.github/workflows/dev-manual.yml
+++ b/.github/workflows/dev-manual.yml
@@ -1,0 +1,57 @@
+name: DevManual
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: DevManual
+    runs-on: ubuntu-latest
+    environment: di-ipv-cri-dev
+    timeout-minutes: 15
+    env:
+      AWS_REGION: eu-west-2
+      ENVIRONMENT: dev
+      STACK_NAME: di-ipv-cri-address-api-dev
+      ROLLBACK_ACTION: "--disable-rollback"
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Setup SAM
+        uses: aws-actions/setup-sam@v1
+
+      - name: Assume temporary AWS role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
+          # role-session-name: ${{ secrets.AWS_ROLE_SESSION }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Gradle build
+        run: ./gradlew clean build
+        
+      - name: SAM Validate
+        run: sam validate --region ${{ env.AWS_REGION }} -t deploy/template.yaml --config-env ${{ env.ENVIRONMENT }}
+
+      - name: SAM build
+        run: sam build -t deploy/template.yaml --config-env ${{ env.ENVIRONMENT }} 
+
+      # - name: Upload API config
+      #   run: aws s3 cp deploy/api.yaml s3://${{ secrets.AWS_CONFIG_BUCKET }}/${{ env.ENVIRONMENT }}/api.yaml
+
+      - name: SAM deploy
+        run: |
+          sam deploy -t deploy/template.yaml --config-env ${{ env.ENVIRONMENT }} \
+            --no-fail-on-empty-changeset --no-confirm-changeset ${{ env.ROLLBACK_ACTION }} \
+            --signing-profiles SessionFunction=${{ secrets.SIGNING_PROFILE_NAME }} \
+            --stack-name ${{ env.STACK_NAME }} --s3-bucket ${{ secrets.ARTIFACT_SOURCE_BUCKET_NAME }} \
+            --s3-prefix ${{ env.STACK_NAME }} --region ${{ env.AWS_REGION }} --capabilities CAPABILITY_IAM \
+            --parameter-overrides CodeSigningConfigArn=${{ secrets.CODE_SIGNING_CONFIG_ARN }}


### PR DESCRIPTION
## Proposed changes

### What changed

Updated the dev deployment to use the same secrets and and more in alignment with the dev-platform team
Dev deployment to be manually triggered

### Why did it change

The change has been made to allow the dev CD be used for testing the workflow with configuration closer aligned to the platform teams process. There is no requirement to have the dev builds automatically run but may prove useful for testing and debugging the process.

### Issue tracking

- [KBV-233](https://govukverify.atlassian.net/browse/KBV-233)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

None