### PR TITLE
BAU Remove AWS::SecretsManager::Secret resource for setting a default Ord…

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -18,10 +18,6 @@ Parameters:
       - integration
       - prod
     ConstraintDescription: specify dev, build, staging, integration or prod for environment
-  OrdnanceSurveyAPIKey:
-    Description: Ordnance Survey API Key
-    Type: String
-    Default: testapikey
 
   OrdnanceSurveyAPIURL:
     Description: Ordnance Survey API URL
@@ -70,8 +66,8 @@ Resources:
       TracingEnabled: true
       Name: !Sub "Address CRI - ${AWS::StackName}"
       StageName: !Sub Environment
-#      Auth:
-#        DefaultAuthorizer: AWS_IAM
+      #      Auth:
+      #        DefaultAuthorizer: AWS_IAM
       DefinitionBody:
         openapi: "3.0.1" # workaround to get `sam validate` to work
         paths: # workaround to get `sam validate` to work
@@ -242,13 +238,6 @@ Resources:
       Type: String
       Name: !Sub /${AWS::StackName}/clients/ipv-core-stub/jwtAuthentication/issuer
       Value: ipv-core-stub
-
-  SecretOrdnanceSurveyAPIKey:
-    Type: AWS::SecretsManager::Secret
-    Properties:
-      Name: !Sub "/${AWS::StackName}/OrdnanceSurveyAPIKey"
-      SecretString: !Ref OrdnanceSurveyAPIKey
-      Description: API key for the Ordnance Survey API
 
   SessionFunctionPermission:
     Type: AWS::Lambda::Permission


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Remove the `AWS::SecretsManager::Secret` resource for setting a default Ordnance Survey API key. This key will be set by hand.

The `ReadSecretsPolicy` policy is retained
