### PR TITLE
Change the session API verb to POST, to make it the same as the KBV s…

### DIFF
--- a/deploy/api.yaml
+++ b/deploy/api.yaml
@@ -45,7 +45,7 @@ paths:
         type: "aws_proxy"
 
   /session:
-    put:
+    post:
       requestBody:
         content:
           application/json:
@@ -100,7 +100,7 @@ components:
         client_id:
           type: "string"
           minLength: 1
-          example: "ipv-core"
+          example: "ipv-core-stub"
         state:
           type: "string"
           example: "state"
@@ -108,7 +108,7 @@ components:
         redirect_uri:
           type: "string"
           format: "uri"
-          example: "https://www.example/com/callback"
+          example: "https://di-ipv-core-stub.london.cloudapps.digital/callback"
         request:
           type: "string"
           pattern: "[a-zA-Z0-9_=]+\\.[a-zA-Z0-9_=]+\\.[a-zA-Z0-9_\\-\\+\\/=]+"

--- a/doc/api.puml
+++ b/doc/api.puml
@@ -22,14 +22,14 @@ end box
 core -[#green]> fe : /authorize\n{ jwt }
 activate fe
 
-fe -> api: PUT /session\n{ jwt }
+fe -> api: POST /session\n{ OAuth as json }
 activate api
 api -> api: validate JWT
 api -> api: create session
 api -> db: write session
 return session-id
 
-
+== Postcode start ==
 
 fe-[#blue]>fe: display post code page
 


### PR DESCRIPTION


## Proposed changes

Change the session API verb to POST, to make it the same as the KBV session API

### What changed

* Update openapi definition
* Update plantUML diagram
* Update session payload examples so they work out the box for ipv-core-stub as client

### Why did it change

Match the KBV session API
