### PR TITLE
KBV-227 Protect Address CRI API with an api key

### DIFF
--- a/infrastructure/lambda/api.yaml
+++ b/infrastructure/lambda/api.yaml
@@ -393,7 +393,14 @@ components:
         currentResidency:
           type: "boolean"
           example: true
-
+#  securitySchemes:
+#    api_key:
+#      type: "apiKey"
+#      name: "x-api-key"
+#      in: "header"
+#
+#security:
+#  - api_key: []
 
 x-amazon-apigateway-request-validators:
   Validate both:

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -286,6 +286,47 @@ Resources:
         AttributeName: expiry-date
         Enabled: true
 
+  ApiUsagePlan:
+    Type: AWS::ApiGateway::UsagePlan
+    DependsOn:
+      - AddressApiStage
+    Properties:
+      ApiStages:
+        - ApiId: !Ref AddressApi
+          Stage: !Ref Environment
+      Quota:
+        Limit: 500000
+        Period: DAY
+      Throttle:
+        BurstLimit: 100 # requests the API can handle concurrently
+        RateLimit: 50 # allowed requests per second
+
+  ApiKey1:
+    Type: AWS::ApiGateway::ApiKey
+    Properties:
+      Description: Api key 1
+      Enabled: true
+
+  ApiKey2:
+    Type: AWS::ApiGateway::ApiKey
+    Properties:
+      Description: Api key 2
+      Enabled: true
+
+  LinkUsagePlanApiKey1:
+    Type: AWS::ApiGateway::UsagePlanKey
+    Properties:
+      KeyId: !Ref ApiKey1
+      KeyType: API_KEY
+      UsagePlanId: !Ref ApiUsagePlan
+
+  LinkUsagePlanApiKey2:
+    Type: AWS::ApiGateway::UsagePlanKey
+    Properties:
+      KeyId: !Ref ApiKey2
+      KeyType: API_KEY
+      UsagePlanId: !Ref ApiUsagePlan
+
   ParameterAddressSessionTableName:
     Type: AWS::SSM::Parameter
     Properties:

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -108,8 +108,6 @@ Resources:
       TracingEnabled: true
       Name: !Sub "address-cri-${AWS::StackName}"
       StageName: !Ref Environment
-      #      Auth:
-      #        DefaultAuthorizer: AWS_IAM
       DefinitionBody:
         openapi: "3.0.1" # workaround to get `sam validate` to work
         paths: # workaround to get `sam validate` to work


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Protect all resources on the Address CRI API by requiring clients to use an API key. These clients are the Address CRI frontend (currently in PaaS) and the IPV Core (cross-account in AWS).

This PR lands the UsagePlan and creates the keys, but does not require clients to use the keys yet.

Clients will have to supply the api key in the http header `x-api-key`.

The API key values can be found in the AWS Console.

This has been tested on a stack in our cri dev environment.

### What changed

* Add two api keys for the address cri api gateway - we provision two so we can share the 2nd key if/when required
* Add an API usage plan for our gateway with burst and rate limits
* Add a commented out usage of that api key in our OpenApi definition. This protects the entire API gateway, but its possible to set this security per resource in OpenApi.


- [KBV-227](https://govukverify.atlassian.net/browse/KBV-227)
