### PR TITLE
BAU: Fix Non key value retrieval for redirectUri

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -174,40 +174,32 @@ Resources:
       TableName: !Sub "address-session-${AWS::StackName}"
       BillingMode: "PAY_PER_REQUEST"
       AttributeDefinitions:
-        -
-          AttributeName: "sessionId"
+        - AttributeName: "sessionId"
           AttributeType: "S"
-        -
-          AttributeName: "authorizationCode"
+        - AttributeName: "authorizationCode"
           AttributeType: "S"
-        -
-          AttributeName: "token"
+        - AttributeName: "token"
           AttributeType: "S"
-
       KeySchema:
-        -
-          AttributeName: "sessionId"
+        - AttributeName: "sessionId"
           KeyType: "HASH"
       GlobalSecondaryIndexes:
-        -
-          IndexName: "authorizationCode-index"
+        - IndexName: "authorizationCode-index"
           KeySchema:
-            -
-              AttributeName: "authorizationCode"
+            - AttributeName: "authorizationCode"
               KeyType: "HASH"
           Projection:
             NonKeyAttributes:
-              - "session-id"
+              - "sessionId"
+              - "redirectUri"
             ProjectionType: "INCLUDE"
-        -
-          IndexName: "token-index"
+        - IndexName: "token-index"
           KeySchema:
-            -
-              AttributeName: "token"
+            - AttributeName: "token"
               KeyType: "HASH"
           Projection:
             NonKeyAttributes:
-              - "session-id"
+              - "sessionId"
             ProjectionType: "INCLUDE"
       TimeToLiveSpecification:
         AttributeName: expiry-date

--- a/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/cri/address/api/handler/AccessTokenHandler.java
+++ b/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/cri/address/api/handler/AccessTokenHandler.java
@@ -13,6 +13,9 @@ import com.nimbusds.oauth2.sdk.TokenResponse;
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import software.amazon.lambda.powertools.logging.CorrelationIdPathConstants;
+import software.amazon.lambda.powertools.logging.Logging;
+import software.amazon.lambda.powertools.metrics.Metrics;
 import uk.gov.di.ipv.cri.address.library.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.cri.address.library.persistence.item.AddressSessionItem;
 import uk.gov.di.ipv.cri.address.library.service.AddressSessionService;
@@ -31,6 +34,9 @@ public class AccessTokenHandler
         this.addressSessionService = new AddressSessionService();
     }
 
+    @Override
+    @Logging(correlationIdPath = CorrelationIdPathConstants.API_GATEWAY_REST)
+    @Metrics(captureColdStart = true)
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
         try {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/address/library/exception/AccessTokenRequestException.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/address/library/exception/AccessTokenRequestException.java
@@ -7,4 +7,8 @@ public class AccessTokenRequestException extends ParseException {
     public AccessTokenRequestException(ErrorObject error) {
         super(error.getCode(), error);
     }
+
+    public AccessTokenRequestException(String message, ErrorObject error) {
+        super(message, error);
+    }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/address/library/persistence/item/AddressSessionItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/address/library/persistence/item/AddressSessionItem.java
@@ -81,4 +81,30 @@ public class AddressSessionItem {
     public String getAuthorizationCode() {
         return authorizationCode;
     }
+
+    @Override
+    public String toString() {
+        return new StringBuilder()
+                .append("AddressSessionItem{")
+                .append("sessionId=")
+                .append(sessionId)
+                .append(", expiryDate=")
+                .append(expiryDate)
+                .append(", clientId='")
+                .append(clientId)
+                .append('\'')
+                .append(", state='")
+                .append(state)
+                .append('\'')
+                .append(", redirectUri=")
+                .append(redirectUri)
+                .append(", accessToken='")
+                .append(accessToken)
+                .append('\'')
+                .append(", authorizationCode='")
+                .append(authorizationCode)
+                .append('\'')
+                .append('}')
+                .toString();
+    }
 }


### PR DESCRIPTION
## Why

When the item is retrieved through the Global Index using the authorizationCode, the `redirectUri` field is blank. This results in a Null pointer Exception

### What changed

Added `redirectUri` as a Non Key Projection to the authorizationCode-index global index

### Other considerations

- The AddressSessionService requires more test coverage this would be added as a subsequent PR