### PR TITLE
[KBV-286] fix lambda CodeUri paths in the SAM template

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -116,7 +116,7 @@ Resources:
   SessionFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: ../lambdas/session/build/distributions/session.zip
+      CodeUri: ../../lambdas/session/build/distributions/session.zip
       Handler: uk.gov.di.ipv.cri.address.api.handler.SessionHandler::handleRequest
       Environment:
         Variables:
@@ -146,7 +146,7 @@ Resources:
   PostcodeLookupFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: ../lambdas/postcode-lookup/build/distributions/postcode-lookup.zip
+      CodeUri: ../../lambdas/postcode-lookup/build/distributions/postcode-lookup.zip
       Handler: uk.gov.di.ipv.cri.address.api.handler.PostcodeLookupHandler::handleRequest
       Environment:
         Variables:
@@ -174,7 +174,7 @@ Resources:
   AccessTokenFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: ../lambdas/accesstoken/build/distributions/accesstoken.zip
+      CodeUri: ../../lambdas/accesstoken/build/distributions/accesstoken.zip
       Handler: uk.gov.di.ipv.cri.address.api.handler.AccessTokenHandler::handleRequest
       Environment:
         Variables:

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -21,7 +21,7 @@ Parameters:
 
 Conditions:
   CreateDevResources: !Equals
-    - !Ref Environment
+    - !Ref EnvironmentName
     - dev
 
 Globals:

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -19,8 +19,28 @@ Parameters:
       - "production"
     ConstraintDescription: must be dev, build, staging, integration or production
 
-Mappings:
+Conditions:
+  CreateDevResources: !Equals
+    - !Ref Environment
+    - dev
 
+Globals:
+  Function:
+    CodeSigningConfigArn: !If
+      - CreateDevResources
+      - !Ref AWS::NoValue
+      - !Ref CodeSigningConfigArn
+    Timeout: 30 # seconds
+    Runtime: java11
+    AutoPublishAlias: live
+    Tracing: Active
+    MemorySize: 512
+    Environment:
+      Variables:
+        AWS_STACK_NAME: !Sub ${AWS::StackName}
+        POWERTOOLS_LOG_LEVEL: INFO
+
+Mappings:
   AddressSessionTtlMapping:
     EnvironmentName:
       dev: "172800" # 2 days
@@ -68,22 +88,6 @@ Mappings:
       staging: "https://api.os.uk/search/places/v1/postcode"
       integration: "https://api.os.uk/search/places/v1/postcode"
       production: "https://api.os.uk/search/places/v1/postcode"
-
-Globals:
-  Function:
-    CodeSigningConfigArn: !If
-      - CreateDevResources
-      - !Ref AWS::NoValue
-      - !Ref CodeSigningConfigArn
-    Timeout: 30 # seconds
-    Runtime: java11
-    AutoPublishAlias: live
-    Tracing: Active
-    MemorySize: 512
-    Environment:
-      Variables:
-        AWS_STACK_NAME: !Sub ${AWS::StackName}
-        POWERTOOLS_LOG_LEVEL: INFO
 
 Resources:
   AddressApi:

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -97,7 +97,7 @@ Resources:
         Format: '{ "requestId":"$context.requestId", "ip": "$context.identity.sourceIp", "caller":"$context.identity.caller", "user":"$context.identity.user","requestTime":"$context.requestTime", "httpMethod":"$context.httpMethod","resourcePath":"$context.resourcePath", "status":"$context.status","protocol":"$context.protocol", "responseLength":"$context.responseLength" }'
       TracingEnabled: true
       Name: !Sub "address-cri-${AWS::StackName}"
-      StageName: !Ref Environment
+      StageName: !Ref EnvironmentName
       #      Auth:
       #        DefaultAuthorizer: AWS_IAM
       DefinitionBody:
@@ -310,13 +310,13 @@ Resources:
 
 Outputs:
   AddressApiBaseUrl:
-    Value: !Sub "https://${AddressApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/"
+    Value: !Sub "https://${AddressApi}.execute-api.${AWS::Region}.amazonaws.com/${EnvironmentName}/"
     Export:
       Name: !Sub ${AWS::StackName}-AddressApiBaseUrl
 
   SessionFunctionApi:
     Description: "API Gateway endpoint URL for Prod stage for session function"
-    Value: !Sub "https://${AddressApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/session/"
+    Value: !Sub "https://${AddressApi}.execute-api.${AWS::Region}.amazonaws.com/${EnvironmentName}/session/"
     Export:
       Name: !Sub ${AWS::StackName}-SessionFunctionApi
   SessionFunction:
@@ -324,7 +324,7 @@ Outputs:
 
   PostcodeLookupFunctionApi:
     Description: "API Gateway endpoint URL for Prod stage for postcode lookup function"
-    Value: !Sub "https://${AddressApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/postcode-lookup/"
+    Value: !Sub "https://${AddressApi}.execute-api.${AWS::Region}.amazonaws.com/${EnvironmentName}/postcode-lookup/"
     Export:
       Name: !Sub ${AWS::StackName}-PostcodeLookupFunctionApi
   PostcodeLookupFunction:


### PR DESCRIPTION
### What changed

Update the lambda CodeUri paths in the SAM template

### Why did it change

The paths need to change to reflect the new location of the template. Without this change the CD will fail.

### Issue tracking

- [KBV-286](https://govukverify.atlassian.net/browse/KBV-286)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

None