### PR TITLE
Updated template.yaml

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -198,7 +198,7 @@ Resources:
   AddressFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: ../lambdas/address/build/distributions/address.zip
+      CodeUri: ../../lambdas/address/build/distributions/address.zip
       Handler: uk.gov.di.ipv.cri.address.api.handler.AddressHandler::handleRequest
       Environment:
         Variables:


### PR DESCRIPTION
Fix incorrect path for Address function

BAU: Template had incorrect parent path for deploying the build artifact for the Address Function