### PR TITLE
[KBV-290] remove environment from staging

### DIFF
--- a/.github/workflows/post-merge-package-for-build.yml
+++ b/.github/workflows/post-merge-package-for-build.yml
@@ -8,7 +8,6 @@ jobs:
   deploy:
     name: Package for build
     runs-on: ubuntu-latest
-    environment: di-ipv-cri-address-build
     timeout-minutes: 15
     env:
       AWS_REGION: eu-west-2

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Manual GitHub actions deployments to di-ipv-cri-address-dev can be triggered fro
 
 The automated deployments are triggered on a push to main after PR approval.
 
-GitHub secrets are required which must be configured in an environment for security reasons.
+GitHub secrets are required for deployment.
 
 Required GitHub secrets:
 
@@ -62,10 +62,3 @@ Required GitHub secrets:
 | GH_ACTIONS_ROLE_ARN | Assumed role IAM ARN |
 | SIGNING_PROFILE_NAME | Signing profile name |
 
-Additional GitHub secrets for the deployment of the parameters
-
-| Secret | Description |
-| ------ | ----------- |
-| PARAM_ARTIFACT_SOURCE_BUCKET_NAME | Upload artifact bucket |
-| PARAM_GH_ACTIONS_ROLE_ARN | Assumed role IAM ARN |
-| PARAM_SIGNING_PROFILE_NAME | Signing profile name |


### PR DESCRIPTION
## Proposed changes

### What changed

Removed GitHub environment from workflow for staging deployment

### Why did it change

GitHub environments and incompatible with the dev platform team's deployment process due to restrictions imposed by AWS.

### Issue tracking

- [KBV-290](https://govukverify.atlassian.net/browse/KBV-290)

## Checklists

### Environment variables or secrets

- [X] Documented in the [README](./blob/main/README.md)

### Other considerations

None