### PR TITLE
KBV-295 Save Authorization request subject identifier to address session data…

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/cri/address/library/domain/SessionRequest.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/address/library/domain/SessionRequest.java
@@ -1,6 +1,7 @@
 package uk.gov.di.ipv.cri.address.library.domain;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.net.URI;
 import java.util.StringJoiner;
@@ -21,6 +22,8 @@ public class SessionRequest {
 
     @JsonAlias("request")
     private String requestJWT;
+
+    @JsonIgnore private transient String subject;
 
     public String getResponseType() {
         return responseType;
@@ -60,6 +63,14 @@ public class SessionRequest {
 
     public void setRequestJWT(String requestJWT) {
         this.requestJWT = requestJWT;
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    public String getSubject() {
+        return subject;
     }
 
     @Override

--- a/lib/src/main/java/uk/gov/di/ipv/cri/address/library/persistence/item/AddressSessionItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/address/library/persistence/item/AddressSessionItem.java
@@ -25,6 +25,7 @@ public class AddressSessionItem {
     private String authorizationCode;
 
     private String accessToken;
+    private String subject;
 
     public AddressSessionItem() {
 
@@ -96,6 +97,14 @@ public class AddressSessionItem {
 
     public void setAddresses(List<CanonicalAddressWithResidency> addresses) {
         this.addresses = Objects.requireNonNullElseGet(addresses, ArrayList::new);
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    public String getSubject() {
+        return subject;
     }
 
     @Override

--- a/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/AddressSessionService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/AddressSessionService.java
@@ -100,6 +100,7 @@ public class AddressSessionService {
         addressSessionItem.setState(sessionRequest.getState());
         addressSessionItem.setClientId(sessionRequest.getClientId());
         addressSessionItem.setRedirectUri(sessionRequest.getRedirectUri());
+        addressSessionItem.setSubject(sessionRequest.getSubject());
         dataStore.create(addressSessionItem);
         return addressSessionItem.getSessionId();
     }
@@ -187,7 +188,9 @@ public class AddressSessionService {
     private SignedJWT parseRequestJWT(SessionRequest sessionRequest)
             throws SessionValidationException {
         try {
-            return SignedJWT.parse(sessionRequest.getRequestJWT());
+            SignedJWT signedJWT = SignedJWT.parse(sessionRequest.getRequestJWT());
+            sessionRequest.setSubject(signedJWT.getJWTClaimsSet().getSubject());
+            return signedJWT;
         } catch (ParseException e) {
             throw new SessionValidationException("Could not parse request JWT", e);
         }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/address/library/service/AddressSessionServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/address/library/service/AddressSessionServiceTest.java
@@ -72,6 +72,7 @@ class AddressSessionServiceTest {
         when(sessionRequest.getState()).thenReturn("state");
         when(sessionRequest.getRedirectUri())
                 .thenReturn(URI.create("https://www.example.com/callback"));
+        when(sessionRequest.getSubject()).thenReturn("a subject");
 
         addressSessionService.createAndSaveAddressSession(sessionRequest);
         verify(mockDataStore).create(mockAddressSessionItem.capture());
@@ -80,6 +81,7 @@ class AddressSessionServiceTest {
         assertThat(capturedValue.getExpiryDate(), equalTo(fixedInstant.getEpochSecond() + 1));
         assertThat(capturedValue.getClientId(), equalTo("a client id"));
         assertThat(capturedValue.getState(), equalTo("state"));
+        assertThat(capturedValue.getSubject(), equalTo("a subject"));
         assertThat(
                 capturedValue.getRedirectUri(),
                 equalTo(URI.create("https://www.example.com/callback")));


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
Save Authorization request subject identifier to address session data store. We need to store the subject as its eventually returned in the verifiable credential.

Here's some evidence:

<img width="1342" alt="Screenshot 2022-03-31 at 09 36 08" src="https://user-images.githubusercontent.com/137389/161016758-efdd2c2c-e655-42d7-9b12-f1a5bc8f7ec7.png">


### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-295](https://govukverify.atlassian.net/browse/KBV-295)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks