### PR TITLE
BAU: Remove Global Secondary index

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -286,8 +286,6 @@ Resources:
           AttributeType: "S"
         - AttributeName: "authorizationCode"
           AttributeType: "S"
-        - AttributeName: "accessToken"
-          AttributeType: "S"
       KeySchema:
         - AttributeName: "sessionId"
           KeyType: "HASH"
@@ -300,14 +298,6 @@ Resources:
             NonKeyAttributes:
               - "sessionId"
               - "redirectUri"
-            ProjectionType: "INCLUDE"
-        - IndexName: "access-token-index"
-          KeySchema:
-            - AttributeName: "accessToken"
-              KeyType: "HASH"
-          Projection:
-            NonKeyAttributes:
-              - "sessionId"
             ProjectionType: "INCLUDE"
       TimeToLiveSpecification:
         AttributeName: expiry-date


### PR DESCRIPTION
This is the first of 2 PR's to fix code-pipeline error
A rename is equivalent to a delete and then an add

This PR is the delete phase, as far as code-pipeline is concerned
there are currently 2 indices,  so once this deployed there wiil be one
i.e token-index is removed

The next PR will add the required access-token-index