### PR TITLE
BAU: add accesstoken gsi index

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -308,6 +308,7 @@ Resources:
           Projection:
             NonKeyAttributes:
               - "sessionId"
+              - "addresses"
             ProjectionType: "INCLUDE"
       TimeToLiveSpecification:
         AttributeName: expiry-date

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -286,6 +286,8 @@ Resources:
           AttributeType: "S"
         - AttributeName: "authorizationCode"
           AttributeType: "S"
+        - AttributeName: "accessToken"
+          AttributeType: "S"
       KeySchema:
         - AttributeName: "sessionId"
           KeyType: "HASH"
@@ -298,6 +300,14 @@ Resources:
             NonKeyAttributes:
               - "sessionId"
               - "redirectUri"
+            ProjectionType: "INCLUDE"
+        - IndexName: "access-token-index"
+          KeySchema:
+            - AttributeName: "accessToken"
+              KeyType: "HASH"
+          Projection:
+            NonKeyAttributes:
+              - "sessionId"
             ProjectionType: "INCLUDE"
       TimeToLiveSpecification:
         AttributeName: expiry-date


### PR DESCRIPTION
This is the 2nd PR, which adds the required access-token-index
See the previous https://github.com/alphagov/di-ipv-cri-address-api/pull/58
