### PR TITLE
BAU: Remove access-token-index

### DIFF
--- a/.github/workflows/post-merge-package-for-build.yml
+++ b/.github/workflows/post-merge-package-for-build.yml
@@ -59,6 +59,7 @@ jobs:
         run: |
           sam package -t infrastructure/lambda/template.yaml  \
             --signing-profiles SessionFunction=${{ secrets.SIGNING_PROFILE_NAME }} \
+            IssueCredentialFunction=${{ secrets.SIGNING_PROFILE_NAME }} \
             PostcodeLookupFunction=${{ secrets.SIGNING_PROFILE_NAME }} \
             AccessTokenFunction=${{ secrets.SIGNING_PROFILE_NAME }} \
             AddressFunction=${{ secrets.SIGNING_PROFILE_NAME }} \

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -286,8 +286,6 @@ Resources:
           AttributeType: "S"
         - AttributeName: "authorizationCode"
           AttributeType: "S"
-        - AttributeName: "accessToken"
-          AttributeType: "S"
       KeySchema:
         - AttributeName: "sessionId"
           KeyType: "HASH"
@@ -300,15 +298,6 @@ Resources:
             NonKeyAttributes:
               - "sessionId"
               - "redirectUri"
-            ProjectionType: "INCLUDE"
-        - IndexName: "access-token-index"
-          KeySchema:
-            - AttributeName: "accessToken"
-              KeyType: "HASH"
-          Projection:
-            NonKeyAttributes:
-              - "sessionId"
-              - "addresses"
             ProjectionType: "INCLUDE"
       TimeToLiveSpecification:
         AttributeName: expiry-date


### PR DESCRIPTION
## Proposed changes
Pipeline failed in build b'cos code signing was left out of this
https://github.com/alphagov/di-ipv-cri-address-api/pull/58
So am redoing it with code-signing applied for build
To the build environment this PR is equivalent to removing the
token-index
