### PR TITLE
KBV-305 - Make AddressCriAudience param value env specific

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -97,6 +97,14 @@ Mappings:
       integration: "https://address-cri.account.gov.uk"
       production: "https://address-cri.account.gov.uk"
 
+  AddressCriAudienceMapping:
+    Environment:
+      dev: "address-cri-dev"
+      build: "address-cri-build"
+      staging: "address-cri-staging"
+      integration: "address-cri-integration"
+      production: "address-cri"
+
 Resources:
   AddressApi:
     Type: AWS::Serverless::Api
@@ -405,7 +413,7 @@ Resources:
     Properties:
       Name: !Sub "/${AWS::StackName}/AddressCriAudience"
       Type: String
-      Value: "address"
+      Value: !FindInMap [AddressCriAudienceMapping, Environment, !Ref 'Environment']
       Description: The address credential issuer (audience) identifier
 
   OrdnanceSurveyAPIURLParameter:


### PR DESCRIPTION
### What changed

The value of the AddressCriAudience SSM parameter (used by the Session lambda function) is assigned on a per environment basis.

### Why did it change
To align with the current credential issuer configuration in di-ipv-config

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-305](https://govukverify.atlassian.net/browse/KBV-305)
