### PR TITLE
KBV-305 Return state and redirect_uri in session API response

### DIFF
--- a/lambdas/session/src/main/java/uk/gov/di/ipv/cri/address/api/handler/SessionHandler.java
+++ b/lambdas/session/src/main/java/uk/gov/di/ipv/cri/address/api/handler/SessionHandler.java
@@ -27,6 +27,8 @@ public class SessionHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     protected static final String SESSION_ID = "session_id";
+    protected static final String STATE = "state";
+    protected static final String REDIRECT_URI = "redirect_uri";
     public static final String EVENT_SESSION_CREATED = "session_created";
     private final AddressSessionService addressSessionService;
     private final EventProbe eventProbe;
@@ -60,7 +62,11 @@ public class SessionHandler
             eventProbe.counterMetric(EVENT_SESSION_CREATED).auditEvent(sessionRequest);
 
             return ApiGatewayResponseGenerator.proxyJsonResponse(
-                    HttpStatus.SC_CREATED, Map.of(SESSION_ID, sessionId.toString()));
+                    HttpStatus.SC_CREATED,
+                    Map.of(
+                            SESSION_ID, sessionId.toString(),
+                            STATE, sessionRequest.getState(),
+                            REDIRECT_URI, sessionRequest.getRedirectUri().toString()));
 
         } catch (SessionValidationException e) {
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Return `state` and `redirect_uri` in session API response so that the frontend can save these values to send back in the auth code redirect.

This is now necessary as the Authorization JWT request now contains these values in the Authorization JAR, rather than as http request params.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-305](https://govukverify.atlassian.net/browse/KBV-305)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks