### PR TITLE
BAU: Set Java tiered compilation level

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -37,6 +37,7 @@ Globals:
     MemorySize: 512
     Environment:
       Variables:
+        JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1
         AWS_STACK_NAME: !Sub ${AWS::StackName}
         POWERTOOLS_LOG_LEVEL: INFO
 


### PR DESCRIPTION
Mark Sailes released a blog post describing how you can reduce cold
start times by setting the Java tiered compilation level. Setting this
global will make the change to all our cri lambdas.

For more details on what this does here's the blog post:
https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/