### PR TITLE
[KBV-349] Fix Address VC Handling of Canonical Address

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/cri/address/library/models/CanonicalAddress.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/address/library/models/CanonicalAddress.java
@@ -5,10 +5,13 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBDocument;
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.nimbusds.jose.shaded.json.JSONObject;
 import uk.gov.di.ipv.cri.address.library.models.ordnancesurvey.Result;
 
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Optional;
+import java.util.TimeZone;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @DynamoDBDocument
@@ -204,5 +207,30 @@ public class CanonicalAddress {
 
     public void setValidUntil(Date validUntil) {
         this.validUntil = validUntil;
+    }
+
+    public JSONObject toJSONObject() {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("uprn", this.getUprn().orElse(null));
+        jsonObject.put("organisationName", this.getOrganisationName());
+        jsonObject.put("departmentName", this.getDepartmentName());
+        jsonObject.put("subBuldingName", this.getSubBuildingName());
+        jsonObject.put("buildingNumber", this.getBuildingNumber());
+        jsonObject.put("buildingName", this.getBuildingName());
+        jsonObject.put("dependentStreetName", this.getDependentStreetName());
+        jsonObject.put("doubleDependentAddressLocality", this.getDoubleDependentAddressLocality());
+        jsonObject.put("dependentAddressLocality", this.getDependentAddressLocality());
+        jsonObject.put("streetName", this.getStreetName());
+        jsonObject.put("addressLocality", this.getAddressLocality());
+        jsonObject.put("postalCode", this.getPostalCode());
+        jsonObject.put("addressCountry", this.getAddressCountry());
+
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd");
+        simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        jsonObject.put("validFrom", this.getValidFrom().map(simpleDateFormat::format).orElse(null));
+        jsonObject.put(
+                "validUntil", this.getValidUntil().map(simpleDateFormat::format).orElse(null));
+
+        return jsonObject;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/VerifiableCredentialService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/VerifiableCredentialService.java
@@ -10,6 +10,7 @@ import uk.gov.di.ipv.cri.address.library.models.CanonicalAddress;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.nimbusds.jwt.JWTClaimNames.EXPIRATION_TIME;
 import static com.nimbusds.jwt.JWTClaimNames.ISSUER;
@@ -67,7 +68,11 @@ public class VerifiableCredentialService {
                                         VC_CONTEXT,
                                         new String[] {W3_BASE_CONTEXT, DI_CONTEXT},
                                         VC_CREDENTIAL_SUBJECT,
-                                        Map.of(VC_ADDRESS_KEY, canonicalAddresses)))
+                                        Map.of(
+                                                VC_ADDRESS_KEY,
+                                                canonicalAddresses.stream()
+                                                        .map(CanonicalAddress::toJSONObject)
+                                                        .collect(Collectors.toList()))))
                         .build();
 
         return signedClaimSetJwt.createSignedJwt(claimsSet);

--- a/lib/src/test/java/uk/gov/di/ipv/cri/address/library/service/VerifiableCredentialServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/address/library/service/VerifiableCredentialServiceTest.java
@@ -76,7 +76,7 @@ public class VerifiableCredentialServiceTest implements TestFixtures {
         verify(mockSignedClaimSetJwt).createSignedJwt(any());
     }
 
-    // @Test
+    @Test
     void shouldCreateValidSignedJWT()
             throws InvalidKeySpecException, NoSuchAlgorithmException, JOSEException, ParseException,
                     JsonProcessingException {

--- a/lib/src/test/java/uk/gov/di/ipv/cri/address/library/service/VerifiableCredentialServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/address/library/service/VerifiableCredentialServiceTest.java
@@ -38,7 +38,7 @@ import static uk.gov.di.ipv.cri.address.library.domain.verifiablecredential.Veri
 import static uk.gov.di.ipv.cri.address.library.domain.verifiablecredential.VerifiableCredentialConstants.VC_CREDENTIAL_SUBJECT;
 
 @ExtendWith(MockitoExtension.class)
-public class VerifiableCredentialServiceTest implements TestFixtures {
+class VerifiableCredentialServiceTest implements TestFixtures {
     public static final String SUBJECT = "subject";
     public static final String UPRN = "72262801";
     public static final String BUILDING_NUMBER = "8";


### PR DESCRIPTION
Use custom parser for converting Canonical Address to a JSONObject (to handle optionals and date formatting)

## Proposed changes

### What changed

- Test re-enabled
- Added a "toJSONObject" method on the Canonical Address to ensure correct serialization

### Why did it change

The Nimbus library masks away its own serialization, which is based on Java 7 types, due to the fact is utilises JSON Compact etc - therefore it doesn't support Optional, nor does it obey Json Attributes when serializing.

### Issue tracking
- [KBV-349](https://govukverify.atlassian.net/browse/KBV-349)

## Checklists

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed
