### PR TITLE
KBV-308 Decryption KMS key per account

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -60,11 +60,11 @@ Mappings:
 
   IPVCoreStubAuthenticationAlgMapping:
     Environment:
-      dev: "RS256"
-      build: "RS256"
-      staging: "RS256"
-      integration: "RS256"
-      production: "RS256"
+      dev: "ES256"
+      build: "ES256"
+      staging: "ES256"
+      integration: "ES256"
+      production: "ES256"
 
   IPVCoreStubAudience:
     Environment:
@@ -89,6 +89,14 @@ Mappings:
       staging: "MIIDJDCCAgwCCQD3oEU83RePojANBgkqhkiG9w0BAQsFADBUMQswCQYDVQQGEwJHQjEXMBUGA1UECgwOQ2FiaW5ldCBPZmZpY2UxDDAKBgNVBAsMA0dEUzEeMBwGA1UEAwwVSVBWIENvcmUgU3R1YiBTaWduaW5nMB4XDTIyMDIwNDE3NDg1NFoXDTMyMDIwMjE3NDg1NFowVDELMAkGA1UEBhMCR0IxFzAVBgNVBAoMDkNhYmluZXQgT2ZmaWNlMQwwCgYDVQQLDANHRFMxHjAcBgNVBAMMFUlQViBDb3JlIFN0dWIgU2lnbmluZzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMT9tGIIujF53SfiHsc+BDra/5qb/PObr8BfutWq4/9kp32eHKOBqTYberXeKJhIS80OB9AC/55QO3V2HdajJJXZbj37shvNy5HcGNxVYRFWt/qyh3+SRTbgfCnfs4QQ6uSLQkJof347qGi26kJU7RuM47grfGCahMvdEOnQgeIHLKw1yqmu8yniy0Lf48jnGlyR6r6QG7UMI2Dk5hdGOEw2WZCoSGLsXII94xS3JKB4sbjEfyuMg87o3pBjoks1LP8KXRcbkBIlc2q8DtEh2YtP57VJfdNhR/gxtHjZhL2E6q+MM158/1xwyXIGcllf+MIserihKEnmsk6wKaJcalcCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAmiAOKd9ZQSjZmIB0GBD1lJaiI1xWwHbwhhuwFsO3YzrIOmB/pDYh0e2FFdsYZ/I48VZn4WQM8mexF/3B2mnG3gXbqHtY8tRPLa0nZq53cOWczKF8RUM2xeWwitYZvfMtx6rRliCUv91IbmKHeGRGiOifOoGxvj8qp30lB2mRBuxP2N4VUAdkqWUjnTdPJr+5eHQeFTbgFg44FxJ59Mz+gGbv4/dQo8ZtFFA/Cqwvz4pevFSken4e9wRF6JGA+AuYdW3tiVutDo/UF+aFir/pDfcrCtyes9xiUv3Iu9x7zKEUG7hwMj0gG83Cvx5SuWJyPb4eKrrdRlRRmLD7PsucUw=="
       integration: "MIIDJDCCAgwCCQD3oEU83RePojANBgkqhkiG9w0BAQsFADBUMQswCQYDVQQGEwJHQjEXMBUGA1UECgwOQ2FiaW5ldCBPZmZpY2UxDDAKBgNVBAsMA0dEUzEeMBwGA1UEAwwVSVBWIENvcmUgU3R1YiBTaWduaW5nMB4XDTIyMDIwNDE3NDg1NFoXDTMyMDIwMjE3NDg1NFowVDELMAkGA1UEBhMCR0IxFzAVBgNVBAoMDkNhYmluZXQgT2ZmaWNlMQwwCgYDVQQLDANHRFMxHjAcBgNVBAMMFUlQViBDb3JlIFN0dWIgU2lnbmluZzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMT9tGIIujF53SfiHsc+BDra/5qb/PObr8BfutWq4/9kp32eHKOBqTYberXeKJhIS80OB9AC/55QO3V2HdajJJXZbj37shvNy5HcGNxVYRFWt/qyh3+SRTbgfCnfs4QQ6uSLQkJof347qGi26kJU7RuM47grfGCahMvdEOnQgeIHLKw1yqmu8yniy0Lf48jnGlyR6r6QG7UMI2Dk5hdGOEw2WZCoSGLsXII94xS3JKB4sbjEfyuMg87o3pBjoks1LP8KXRcbkBIlc2q8DtEh2YtP57VJfdNhR/gxtHjZhL2E6q+MM158/1xwyXIGcllf+MIserihKEnmsk6wKaJcalcCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAmiAOKd9ZQSjZmIB0GBD1lJaiI1xWwHbwhhuwFsO3YzrIOmB/pDYh0e2FFdsYZ/I48VZn4WQM8mexF/3B2mnG3gXbqHtY8tRPLa0nZq53cOWczKF8RUM2xeWwitYZvfMtx6rRliCUv91IbmKHeGRGiOifOoGxvj8qp30lB2mRBuxP2N4VUAdkqWUjnTdPJr+5eHQeFTbgFg44FxJ59Mz+gGbv4/dQo8ZtFFA/Cqwvz4pevFSken4e9wRF6JGA+AuYdW3tiVutDo/UF+aFir/pDfcrCtyes9xiUv3Iu9x7zKEUG7hwMj0gG83Cvx5SuWJyPb4eKrrdRlRRmLD7PsucUw=="
       production: "MIIDJDCCAgwCCQD3oEU83RePojANBgkqhkiG9w0BAQsFADBUMQswCQYDVQQGEwJHQjEXMBUGA1UECgwOQ2FiaW5ldCBPZmZpY2UxDDAKBgNVBAsMA0dEUzEeMBwGA1UEAwwVSVBWIENvcmUgU3R1YiBTaWduaW5nMB4XDTIyMDIwNDE3NDg1NFoXDTMyMDIwMjE3NDg1NFowVDELMAkGA1UEBhMCR0IxFzAVBgNVBAoMDkNhYmluZXQgT2ZmaWNlMQwwCgYDVQQLDANHRFMxHjAcBgNVBAMMFUlQViBDb3JlIFN0dWIgU2lnbmluZzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMT9tGIIujF53SfiHsc+BDra/5qb/PObr8BfutWq4/9kp32eHKOBqTYberXeKJhIS80OB9AC/55QO3V2HdajJJXZbj37shvNy5HcGNxVYRFWt/qyh3+SRTbgfCnfs4QQ6uSLQkJof347qGi26kJU7RuM47grfGCahMvdEOnQgeIHLKw1yqmu8yniy0Lf48jnGlyR6r6QG7UMI2Dk5hdGOEw2WZCoSGLsXII94xS3JKB4sbjEfyuMg87o3pBjoks1LP8KXRcbkBIlc2q8DtEh2YtP57VJfdNhR/gxtHjZhL2E6q+MM158/1xwyXIGcllf+MIserihKEnmsk6wKaJcalcCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAmiAOKd9ZQSjZmIB0GBD1lJaiI1xWwHbwhhuwFsO3YzrIOmB/pDYh0e2FFdsYZ/I48VZn4WQM8mexF/3B2mnG3gXbqHtY8tRPLa0nZq53cOWczKF8RUM2xeWwitYZvfMtx6rRliCUv91IbmKHeGRGiOifOoGxvj8qp30lB2mRBuxP2N4VUAdkqWUjnTdPJr+5eHQeFTbgFg44FxJ59Mz+gGbv4/dQo8ZtFFA/Cqwvz4pevFSken4e9wRF6JGA+AuYdW3tiVutDo/UF+aFir/pDfcrCtyes9xiUv3Iu9x7zKEUG7hwMj0gG83Cvx5SuWJyPb4eKrrdRlRRmLD7PsucUw=="
+
+  IPVCoreStubPublicSigningJwkBase64Mapping:
+    Environment:
+      dev: "ewogICAgImt0eSI6ICJFQyIsCiAgICAidXNlIjogInNpZyIsCiAgICAiY3J2IjogIlAtMjU2IiwKICAgICJraWQiOiAiaXB2LWNvcmUtc3R1Yi0xLWZyb20tbWtqd2sub3JnIiwKICAgICJ4IjogIklmUjFQejlPdWNJMll3YldKVGEtT3h0MDJ6X3pnTkR5RmtocGZ3OFFXcjAiLAogICAgInkiOiAiWGo2alJ6S0EwUWVTTEMtZTE1bVg3U2hucG9xZ0c4d1F3ZWcwNlhJYTBEcyIsCiAgICAiYWxnIjogIkVTMjU2Igp9"
+      build: "ewogICAgImt0eSI6ICJFQyIsCiAgICAidXNlIjogInNpZyIsCiAgICAiY3J2IjogIlAtMjU2IiwKICAgICJraWQiOiAiaXB2LWNvcmUtc3R1Yi0xLWZyb20tbWtqd2sub3JnIiwKICAgICJ4IjogIklmUjFQejlPdWNJMll3YldKVGEtT3h0MDJ6X3pnTkR5RmtocGZ3OFFXcjAiLAogICAgInkiOiAiWGo2alJ6S0EwUWVTTEMtZTE1bVg3U2hucG9xZ0c4d1F3ZWcwNlhJYTBEcyIsCiAgICAiYWxnIjogIkVTMjU2Igp9"
+      staging: "ewogICAgImt0eSI6ICJFQyIsCiAgICAidXNlIjogInNpZyIsCiAgICAiY3J2IjogIlAtMjU2IiwKICAgICJraWQiOiAiaXB2LWNvcmUtc3R1Yi0xLWZyb20tbWtqd2sub3JnIiwKICAgICJ4IjogIklmUjFQejlPdWNJMll3YldKVGEtT3h0MDJ6X3pnTkR5RmtocGZ3OFFXcjAiLAogICAgInkiOiAiWGo2alJ6S0EwUWVTTEMtZTE1bVg3U2hucG9xZ0c4d1F3ZWcwNlhJYTBEcyIsCiAgICAiYWxnIjogIkVTMjU2Igp9"
+      integration: "ewogICAgImt0eSI6ICJFQyIsCiAgICAidXNlIjogInNpZyIsCiAgICAiY3J2IjogIlAtMjU2IiwKICAgICJraWQiOiAiaXB2LWNvcmUtc3R1Yi0xLWZyb20tbWtqd2sub3JnIiwKICAgICJ4IjogIklmUjFQejlPdWNJMll3YldKVGEtT3h0MDJ6X3pnTkR5RmtocGZ3OFFXcjAiLAogICAgInkiOiAiWGo2alJ6S0EwUWVTTEMtZTE1bVg3U2hucG9xZ0c4d1F3ZWcwNlhJYTBEcyIsCiAgICAiYWxnIjogIkVTMjU2Igp9"
+      production: "ewogICAgImt0eSI6ICJFQyIsCiAgICAidXNlIjogInNpZyIsCiAgICAiY3J2IjogIlAtMjU2IiwKICAgICJraWQiOiAiaXB2LWNvcmUtc3R1Yi0xLWZyb20tbWtqd2sub3JnIiwKICAgICJ4IjogIklmUjFQejlPdWNJMll3YldKVGEtT3h0MDJ6X3pnTkR5RmtocGZ3OFFXcjAiLAogICAgInkiOiAiWGo2alJ6S0EwUWVTTEMtZTE1bVg3U2hucG9xZ0c4d1F3ZWcwNlhJYTBEcyIsCiAgICAiYWxnIjogIkVTMjU2Igp9"
 
   IPVCoreStubRedirectURIMapping:
     Environment:
@@ -129,14 +137,6 @@ Mappings:
       staging: "address-cri-staging"
       integration: "address-cri-integration"
       production: "address-cri"
-
-  AuthRequestKmsEncryptionKeyIdMapping:
-    Environment:
-      dev: "610ae2fc-75a1-44d7-b54c-6ee85de10871qq"
-      build: "TBA"
-      staging: "TBA"
-      integration: "TBA"
-      production: "TBA"
 
 Resources:
   AddressApi:
@@ -185,7 +185,7 @@ Resources:
             TableName:
               Ref: AddressSessionTable
         - KMSDecryptPolicy:
-            KeyId: "610ae2fc-75a1-44d7-b54c-6ee85de10871"
+            KeyId: !Ref AddressCriAuthJarDecryptionKey
         - Statement:
             - Effect: Allow
               Action:
@@ -230,6 +230,7 @@ Resources:
                 - ssm:GetParameter
               Resource:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/OrdnanceSurveyAPIURL"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/AuthRequestKmsEncryptionKeyId"
         - Statement:
             - Effect: Allow
               Action:
@@ -266,6 +267,7 @@ Resources:
               Resource:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/AddressSessionTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/AddressSessionTtl"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/AuthRequestKmsEncryptionKeyId"
         - Statement:
             - Effect: Allow
               Action:
@@ -296,6 +298,7 @@ Resources:
               Resource:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/AddressSessionTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/AddressSessionTtl"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/AuthRequestKmsEncryptionKeyId"
         - Statement:
             - Effect: Allow
               Action:
@@ -344,6 +347,7 @@ Resources:
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/MaxJwtTtl"
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/verifiable-credential/issuer"
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/verifiableCredentialKmsSigningKeyId"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/AuthRequestKmsEncryptionKeyId"
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
         - arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess
@@ -390,6 +394,29 @@ Resources:
       AliasName: !Sub alias/${AWS::StackName}/${Environment}/AddressCriVcSigningKey
       TargetKeyId: !Ref AddressCriVcSigningKey
 
+  AddressCriAuthJarDecryptionKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: Asymmetric key used by Address CRI to decrypt the Authorization JAR JWE
+      Enabled: true
+      KeySpec: RSA_2048
+      KeyUsage: ENCRYPT_DECRYPT
+      KeyPolicy:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: 'Enable Root access'
+            Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action:
+              - 'kms:*'
+            Resource: '*'
+
+  DecryptionKeyAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: !Sub alias/${AWS::StackName}/${Environment}/AddressCriAuthJarDecryptionKey
+      TargetKeyId: !Ref AddressCriAuthJarDecryptionKey
 
   AddressSessionTable:
     Type: "AWS::DynamoDB::Table"
@@ -522,6 +549,13 @@ Resources:
       Type: String
       Value: !FindInMap [IPVCoreStubPublicCertificateToVerifyMapping, Environment, !Ref 'Environment']
 
+  IPVCoreStubPublicSigningJwkBase64Parameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/clients/ipv-core-stub/jwtAuthentication/publicSigningJwkBase64"
+      Type: String
+      Value: !FindInMap [IPVCoreStubPublicSigningJwkBase64Mapping, Environment, !Ref 'Environment']
+
   IPVCoreStubRedirectURIParameter:
     Type: AWS::SSM::Parameter
     Properties:
@@ -542,7 +576,7 @@ Resources:
     Properties:
       Name: !Sub "/${AWS::StackName}/AuthRequestKmsEncryptionKeyId"
       Type: String
-      Value: !FindInMap [AuthRequestKmsEncryptionKeyIdMapping, Environment, !Ref 'Environment']
+      Value: !Ref AddressCriAuthJarDecryptionKey
       Description: The (KMS) encryption key identifier for decrypting authorisation requests
 
   OrdnanceSurveyAPIURLParameter:

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -185,7 +185,7 @@ Resources:
             TableName:
               Ref: AddressSessionTable
         - KMSDecryptPolicy:
-            KeyId: !Ref AddressCriAuthJarDecryptionKey
+            KeyId: !Ref AddressCriDecryptionKey
         - Statement:
             - Effect: Allow
               Action:
@@ -394,7 +394,7 @@ Resources:
       AliasName: !Sub alias/${AWS::StackName}/${Environment}/AddressCriVcSigningKey
       TargetKeyId: !Ref AddressCriVcSigningKey
 
-  AddressCriAuthJarDecryptionKey:
+  AddressCriDecryptionKey:
     Type: AWS::KMS::Key
     Properties:
       Description: Asymmetric key used by Address CRI to decrypt the Authorization JAR JWE
@@ -415,8 +415,8 @@ Resources:
   DecryptionKeyAlias:
     Type: AWS::KMS::Alias
     Properties:
-      AliasName: !Sub alias/${AWS::StackName}/${Environment}/AddressCriAuthJarDecryptionKey
-      TargetKeyId: !Ref AddressCriAuthJarDecryptionKey
+      AliasName: !Sub alias/${AWS::StackName}/${Environment}/AddressCriDecryptionKey
+      TargetKeyId: !Ref AddressCriDecryptionKey
 
   AddressSessionTable:
     Type: "AWS::DynamoDB::Table"
@@ -576,7 +576,7 @@ Resources:
     Properties:
       Name: !Sub "/${AWS::StackName}/AuthRequestKmsEncryptionKeyId"
       Type: String
-      Value: !Ref AddressCriAuthJarDecryptionKey
+      Value: !Ref AddressCriDecryptionKey
       Description: The (KMS) encryption key identifier for decrypting authorisation requests
 
   OrdnanceSurveyAPIURLParameter:

--- a/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/JWTVerifier.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/JWTVerifier.java
@@ -54,8 +54,7 @@ class JWTVerifier {
     private void verifyJWTSignature(
             Map<String, String> clientAuthenticationConfig, SignedJWT signedJWT)
             throws SessionValidationException, ClientConfigurationException {
-        String publicCertificateToVerify =
-                clientAuthenticationConfig.get("publicCertificateToVerify");
+        String publicCertificateToVerify = clientAuthenticationConfig.get("publicSigningJwkBase64");
         try {
             JWSAlgorithm signingAlgorithm = signedJWT.getHeader().getAlgorithm();
             PublicKey pubicKeyFromConfig =
@@ -100,7 +99,8 @@ class JWTVerifier {
                     factory.generateCertificate(new ByteArrayInputStream(binaryCertificate));
             return certificate.getPublicKey();
         } else if (JWSAlgorithm.Family.EC.contains(signingAlgorithm)) {
-            return new ECKey.Builder(ECKey.parse(serialisedPublicKey)).build().toECPublicKey();
+            return ECKey.parse(new String(Base64.getDecoder().decode(serialisedPublicKey)))
+                    .toECPublicKey();
         } else {
             throw new IllegalArgumentException(
                     "Unexpected signing algorithm encountered: " + signingAlgorithm.getName());

--- a/lib/src/test/java/uk/gov/di/ipv/cri/address/library/service/JWTVerifierTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/address/library/service/JWTVerifierTest.java
@@ -3,7 +3,9 @@ package uk.gov.di.ipv.cri.address.library.service;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.ECDSASigner;
 import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,6 +20,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
+import java.text.ParseException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
@@ -44,6 +47,12 @@ class JWTVerifierTest {
 
     private final String publicCertificate =
             "MIIFVjCCAz4CCQDGbJ/u6uFT6DANBgkqhkiG9w0BAQsFADBtMQswCQYDVQQGEwJHQjENMAsGA1UECAwEVGVzdDENMAsGA1UEBwwEVGVzdDENMAsGA1UECgwEVEVzdDENMAsGA1UECwwEVEVzdDENMAsGA1UEAwwEVEVzdDETMBEGCSqGSIb3DQEJARYEVGVzdDAeFw0yMjAxMDcxNTM0NTlaFw0yMzAxMDcxNTM0NTlaMG0xCzAJBgNVBAYTAkdCMQ0wCwYDVQQIDARUZXN0MQ0wCwYDVQQHDARUZXN0MQ0wCwYDVQQKDARURXN0MQ0wCwYDVQQLDARURXN0MQ0wCwYDVQQDDARURXN0MRMwEQYJKoZIhvcNAQkBFgRUZXN0MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAy1cVZ1KfFmgFlDQyf/R3LF/Js6jAS2Zzbs8WGSS0ys6Z+XR4x5DTIznZp5cHuuQmqOFylXSw5oGBwMXd2L6NimG9rJnJ4w8Gy5A6ImGsiDZC+3AXRBb5hq/IdDTBjbUqRxAKokSVwotWZt554BdSRPTmlYDujzxnClNKA06Xb/X3rTsgCUmZhUnSVtOzKytP3Bdv88VI5gq5tlZOtKXCB0PnJOqRbBmuL1RNkeTny4ZJW3I2ywSATwDDyDm4pJ8XGGNFKaYYTwr6uNTQ2VHb1FVC33oWbg+Zu9D4p5l7ONicCCF3V+GbvmyeCmHGnXznz0nYX1LFqaKtruEh3/GXyLy5X03Jzq6HhTf1SNFBmzziuCovhbR4v5aFDqAYNPWz+ajOdTUfP1I18c5jR1xGUxEiiLKBZWU1J5mhqCa+0CdI0mi3HwFmluudh47I2Xw++JiqZQpxRqNGcKJOPnWDgKOKXQ/ag37aJkxqoYWk9pQ/pXOdIKm//+B//8nWGo8BA/bfdmMHyzhWWxqtydjie2EZ5ODSdQ+yu1xU5cwP59BEQoU7FKVEGiJa4kzrsI2cgloUPlsPfLENMa5i09exDo//eDB/zNy9ACgGCriov1ex3uv4vHp3WtpZYe+akGEJeP0N5dejs0hkBuX+LUcM30TnQ424tEzcuaJ1F7r4FP0CAwEAATANBgkqhkiG9w0BAQsFAAOCAgEAUh5gZx8S/XoZZoQai2uTyW/lyr1LpXMQyfvdWRr5+/OtFuASG3fAPXOTiUfuqH6Uma8BaXPRbSGWxBOFg0EbyvUY4UczZXZgVqyzkGjD2bVcnGra1OHz2AkcJm7OvzjMUvmXdDiQ8WcKIH16BZVsJFveTffJbM/KxL9UUdSLT0fNw1OvZWN1LxRj+X16B26ZnmaXPdmEC8MfwNcEU63qSlIbAvLg9Dp03weqO1qWR1vI/n1jwqidCUVwT0XF88/pJrds8/8guKlawhp9Yv+jMVYaawBiALR+5PFN56DivtmSVI5uv3oFh5tqJXXn9PhsPcIq0YKGQvvcdZl7vCikS65VzmswXBVFJNsYeeZ5NmiH2ANQd4+BLetgLAoXZxaOJ4nK+3Ml+gMwpZRRAbtixKJQDtVy+Ahuh1TEwTS1CERDYq43LhVYbMcgxdOLpZLvMew2tvJc3HfSWQKuF+NjGn/RwG54GyhjpdbfNZMB/EJXNJMt1j9RSVbPLsWjaENUkZoXE0otSou9tJOR0fwoqBJGUi5GCp98+iBdIQMAvXW5JkoDS6CM1FOfSv9ZXLvfXHOuBfKTDeVNy7u3QvyJ+BdkSc0iH4gj1F2zLHNIaZbDzwRzcDf2s3D1wTtoJ/WxfRSLGBMuUsXSduh9Md1S862N3Ce6wpri1IsgySCP84Y=";
+
+    private final String publicSigningJwkBase64 =
+            "ewogICAgImt0eSI6ICJFQyIsCiAgICAidXNlIjogInNpZyIsCiAgICAiY3J2IjogIlAtMjU2IiwKICAgICJraWQiOiAiaXB2LWNvcmUtc3R1Yi0xLWZyb20tbWtqd2sub3JnIiwKICAgICJ4IjogIklmUjFQejlPdWNJMll3YldKVGEtT3h0MDJ6X3pnTkR5RmtocGZ3OFFXcjAiLAogICAgInkiOiAiWGo2alJ6S0EwUWVTTEMtZTE1bVg3U2hucG9xZ0c4d1F3ZWcwNlhJYTBEcyIsCiAgICAiYWxnIjogIkVTMjU2Igp9";
+
+    private final String privateSigningJwkBase64 =
+            "ewogICAgImt0eSI6ICJFQyIsCiAgICAiZCI6ICI1MzRnaFRadVN0UkE4SFQwY0Y0NFprWl84YTkwWTJiY3R5akdKekpoVG8wIiwKICAgICJ1c2UiOiAic2lnIiwKICAgICJjcnYiOiAiUC0yNTYiLAogICAgImtpZCI6ICJpcHYtY29yZS1zdHViLTEtZnJvbS1ta2p3ay5vcmciLAogICAgIngiOiAiSWZSMVB6OU91Y0kyWXdiV0pUYS1PeHQwMnpfemdORHlGa2hwZnc4UVdyMCIsCiAgICAieSI6ICJYajZqUnpLQTBRZVNMQy1lMTVtWDdTaG5wb3FnRzh3UXdlZzA2WElhMERzIiwKICAgICJhbGciOiAiRVMyNTYiCn0=";
 
     @BeforeEach
     void setup() {
@@ -141,7 +150,7 @@ class JWTVerifierTest {
                 Map.of(
                         "issuer",
                         "https://dev.core.ipv.account.gov.uk",
-                        "publicCertificateToVerify",
+                        "publicSigningJwkBase64",
                         wrongPublicCertificate,
                         "authenticationAlg",
                         "RS256",
@@ -188,6 +197,28 @@ class JWTVerifierTest {
 
         RSASSASigner rsaSigner = new RSASSASigner(getPrivateKey());
         signedJWT.sign(rsaSigner);
+
+        assertDoesNotThrow(
+                () -> jwtVerifier.verifyJWT(clientConfigMap, signedJWT, getRequiredClaims()));
+    }
+
+    @Test
+    void shouldValidateJWTSignedWithECKey() throws JOSEException, ParseException {
+        Map<String, String> clientConfigMap = getECSSMClientConfig();
+        SignedJWT signedJWT =
+                new SignedJWT(
+                        new JWSHeader.Builder(JWSAlgorithm.ES256).build(),
+                        new JWTClaimsSet.Builder()
+                                .issuer("https://dev.core.ipv.account.gov.uk")
+                                .notBeforeTime(Date.from(now))
+                                .audience("https://address.cri.account.gov.uk")
+                                .subject(UUID.randomUUID().toString())
+                                .expirationTime(Date.from(now.plus(1, ChronoUnit.HOURS)))
+                                .build());
+
+        ECDSASigner ecdsaSigner = new ECDSASigner(getECPrivateKey());
+
+        signedJWT.sign(ecdsaSigner);
 
         assertDoesNotThrow(
                 () -> jwtVerifier.verifyJWT(clientConfigMap, signedJWT, getRequiredClaims()));
@@ -311,10 +342,22 @@ class JWTVerifierTest {
         return Map.of(
                 "issuer",
                 "https://dev.core.ipv.account.gov.uk",
-                "publicCertificateToVerify",
+                "publicSigningJwkBase64",
                 publicCertificate,
                 "authenticationAlg",
                 "RS256",
+                "audience",
+                "https://address.cri.account.gov.uk");
+    }
+
+    private Map<String, String> getECSSMClientConfig() {
+        return Map.of(
+                "issuer",
+                "https://dev.core.ipv.account.gov.uk",
+                "publicSigningJwkBase64",
+                publicSigningJwkBase64,
+                "authenticationAlg",
+                "ES256",
                 "audience",
                 "https://address.cri.account.gov.uk");
     }
@@ -324,6 +367,10 @@ class JWTVerifierTest {
                 KeyFactory.getInstance("RSA")
                         .generatePrivate(
                                 new PKCS8EncodedKeySpec(Base64.getDecoder().decode(privateKey)));
+    }
+
+    private ECKey getECPrivateKey() throws ParseException {
+        return ECKey.parse(new String(Base64.getDecoder().decode(privateSigningJwkBase64)));
     }
 
     private List<String> getRequiredClaims() {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Add Auth JAR Decryption KMS key per account. Wire in the KMS key id to decrypt policies.

Also add an SSM param at `/${AWS::StackName}/clients/ipv-core-stub/jwtAuthentication/publicSigningJwkBase64` that supports using a public key JWK for sig verification.

### Why did it change

Switched from one hardcoded KMS key id configured for the dev account to a provisioned KSM decrypt key per stack on an account.


<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-308](https://govukverify.atlassian.net/browse/KBV-308)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks