### PR TITLE
KBV-347: refactored changes for nbf based 

### DIFF
--- a/lambdas/session/src/main/java/uk/gov/di/ipv/cri/address/api/service/SessionRequestService.java
+++ b/lambdas/session/src/main/java/uk/gov/di/ipv/cri/address/api/service/SessionRequestService.java
@@ -15,9 +15,9 @@ import uk.gov.di.ipv.cri.address.library.service.JWTVerifier;
 
 import java.net.URI;
 import java.text.ParseException;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 public class SessionRequestService {
     private static final String REDIRECT_URI = "redirect_uri";
@@ -59,7 +59,7 @@ public class SessionRequestService {
         jwtVerifier.verifyJWT(
                 clientAuthenticationConfig,
                 sessionRequest.getSignedJWT(),
-                List.of(
+                Set.of(
                         JWTClaimNames.EXPIRATION_TIME,
                         JWTClaimNames.SUBJECT,
                         JWTClaimNames.NOT_BEFORE));

--- a/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/AccessTokenService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/AccessTokenService.java
@@ -1,7 +1,6 @@
 package uk.gov.di.ipv.cri.address.library.service;
 
 import com.nimbusds.common.contenttype.ContentType;
-import com.nimbusds.jwt.JWTClaimNames;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.AccessTokenResponse;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
@@ -140,10 +139,7 @@ public class AccessTokenService {
                             tokenRequest.getClientAuthentication().getClientID().getValue());
             SignedJWT signedJWT = privateKeyJWT.getClientAssertion();
 
-            jwtVerifier.verifyJWT(
-                    clientAuthenticationConfig,
-                    signedJWT,
-                    List.of(JWTClaimNames.EXPIRATION_TIME, JWTClaimNames.SUBJECT));
+            jwtVerifier.verifyJWT(clientAuthenticationConfig, signedJWT);
             return tokenRequest;
         } catch (SessionValidationException
                 | ClientConfigurationException

--- a/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/JWTVerifier.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/JWTVerifier.java
@@ -5,6 +5,7 @@ import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.crypto.ECDSAVerifier;
 import com.nimbusds.jose.crypto.RSASSAVerifier;
 import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jwt.JWTClaimNames;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.jwt.proc.BadJWTException;
@@ -21,19 +22,28 @@ import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAPublicKey;
 import java.text.ParseException;
 import java.util.Base64;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class JWTVerifier {
 
     public void verifyJWT(
             Map<String, String> clientAuthenticationConfig,
             SignedJWT signedJWT,
-            List<String> requiredClaims)
+            Set<String> requiredClaims)
             throws SessionValidationException, ClientConfigurationException {
         this.verifyJWTHeader(clientAuthenticationConfig, signedJWT);
         this.verifyJWTClaimsSet(clientAuthenticationConfig, signedJWT, requiredClaims);
+        this.verifyJWTSignature(clientAuthenticationConfig, signedJWT);
+    }
+
+    public void verifyJWT(Map<String, String> clientAuthenticationConfig, SignedJWT signedJWT)
+            throws SessionValidationException, ClientConfigurationException {
+        this.verifyJWTHeader(clientAuthenticationConfig, signedJWT);
+        this.verifyJWTClaimsSet(
+                clientAuthenticationConfig,
+                signedJWT,
+                Set.of(JWTClaimNames.EXPIRATION_TIME, JWTClaimNames.SUBJECT));
         this.verifyJWTSignature(clientAuthenticationConfig, signedJWT);
     }
 
@@ -72,7 +82,7 @@ public class JWTVerifier {
     private void verifyJWTClaimsSet(
             Map<String, String> clientAuthenticationConfig,
             SignedJWT signedJWT,
-            List<String> requiredClaims)
+            Set<String> requiredClaims)
             throws SessionValidationException {
         DefaultJWTClaimsVerifier<?> verifier =
                 new DefaultJWTClaimsVerifier<>(
@@ -80,12 +90,12 @@ public class JWTVerifier {
                                 .issuer(clientAuthenticationConfig.get("issuer"))
                                 .audience(clientAuthenticationConfig.get("audience"))
                                 .build(),
-                        new HashSet<>(requiredClaims));
+                        requiredClaims);
 
         try {
             verifier.verify(signedJWT.getJWTClaimsSet(), null);
         } catch (BadJWTException | ParseException e) {
-            throw new SessionValidationException(e.getMessage(), e);
+            throw new SessionValidationException(e.getMessage());
         }
     }
 

--- a/lib/src/test/java/uk/gov/di/ipv/cri/address/library/service/JWTVerifierTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/address/library/service/JWTVerifierTest.java
@@ -25,8 +25,8 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.Date;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -330,7 +330,7 @@ class JWTVerifierTest {
                                 jwtVerifier.verifyJWT(
                                         clientConfigMap,
                                         signedJWT,
-                                        List.of(
+                                        Set.of(
                                                 JWTClaimNames.EXPIRATION_TIME,
                                                 JWTClaimNames.SUBJECT,
                                                 JWTClaimNames.NOT_BEFORE)));
@@ -373,7 +373,7 @@ class JWTVerifierTest {
         return ECKey.parse(new String(Base64.getDecoder().decode(privateSigningJwkBase64)));
     }
 
-    private List<String> getRequiredClaims() {
-        return List.of(JWTClaimNames.EXPIRATION_TIME, JWTClaimNames.SUBJECT);
+    private Set<String> getRequiredClaims() {
+        return Set.of(JWTClaimNames.EXPIRATION_TIME, JWTClaimNames.SUBJECT);
     }
 }


### PR DESCRIPTION
Refactoring based on comments during morning tech catchup.

Changes:

- Refactored `verifyJWT` method to create an overloaded counterpart which accepts `Set` collection of claims 
- Used nimbus `JWTClaimNames` object for claims

