### PR TITLE
BAU: Refactor credential issue endpoint artefacts

### DIFF
--- a/lambdas/issuecredential/build.gradle
+++ b/lambdas/issuecredential/build.gradle
@@ -8,7 +8,8 @@ dependencies {
 	implementation project(":lib"),
 			configurations.lambda,
 			configurations.nimbus,
-			configurations.dynamodb
+			configurations.dynamodb,
+			configurations.jackson
 
 	aspect configurations.powertools
 

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/domain/VerifiableCredentialConstants.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/domain/VerifiableCredentialConstants.java
@@ -1,4 +1,4 @@
-package uk.gov.di.ipv.cri.address.library.domain.verifiablecredential;
+package uk.gov.di.ipv.cri.address.api.domain;
 
 public class VerifiableCredentialConstants {
     public static final String VC_CONTEXT = "@context";
@@ -8,8 +8,6 @@ public class VerifiableCredentialConstants {
     public static final String VC_TYPE = "type";
     public static final String VERIFIABLE_CREDENTIAL_TYPE = "VerifiableCredential";
     public static final String ADDRESS_CREDENTIAL_TYPE = "AddressCredential";
-    public static final String CREDENTIAL_SUBJECT_NAME = "name";
-    public static final String CREDENTIAL_SUBJECT_ADDRESS = "address";
     public static final String VC_CREDENTIAL_SUBJECT = "credentialSubject";
     public static final String VC_CLAIM = "vc";
     public static final String VC_ADDRESS_KEY = "address";

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/exception/CredentialRequestException.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/exception/CredentialRequestException.java
@@ -1,14 +1,10 @@
-package uk.gov.di.ipv.cri.address.library.exception;
+package uk.gov.di.ipv.cri.address.api.exception;
 
 import uk.gov.di.ipv.cri.address.library.error.ErrorResponse;
 
 public class CredentialRequestException extends Exception {
     public CredentialRequestException(ErrorResponse invalidRequestParam) {
         super(invalidRequestParam.getMessage());
-    }
-
-    public CredentialRequestException(String message) {
-        super(message);
     }
 
     public CredentialRequestException(String message, Exception e) {

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/handler/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/handler/IssueCredentialHandler.java
@@ -14,15 +14,15 @@ import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.lambda.powertools.logging.CorrelationIdPathConstants;
 import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.metrics.Metrics;
+import uk.gov.di.ipv.cri.address.api.exception.CredentialRequestException;
+import uk.gov.di.ipv.cri.address.api.service.VerifiableCredentialService;
 import uk.gov.di.ipv.cri.address.library.error.ErrorResponse;
-import uk.gov.di.ipv.cri.address.library.exception.CredentialRequestException;
 import uk.gov.di.ipv.cri.address.library.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.cri.address.library.helpers.EventProbe;
 import uk.gov.di.ipv.cri.address.library.helpers.ListUtil;
 import uk.gov.di.ipv.cri.address.library.persistence.DataStore;
 import uk.gov.di.ipv.cri.address.library.persistence.item.AddressSessionItem;
 import uk.gov.di.ipv.cri.address.library.service.ConfigurationService;
-import uk.gov.di.ipv.cri.address.library.service.VerifiableCredentialService;
 
 import java.util.Map;
 import java.util.Optional;

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/service/VerifiableCredentialService.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/service/VerifiableCredentialService.java
@@ -1,4 +1,4 @@
-package uk.gov.di.ipv.cri.address.library.service;
+package uk.gov.di.ipv.cri.address.api.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
@@ -8,6 +8,7 @@ import com.nimbusds.jwt.SignedJWT;
 import uk.gov.di.ipv.cri.address.library.helpers.KMSSigner;
 import uk.gov.di.ipv.cri.address.library.helpers.SignClaimSetJwt;
 import uk.gov.di.ipv.cri.address.library.models.CanonicalAddress;
+import uk.gov.di.ipv.cri.address.library.service.ConfigurationService;
 
 import java.time.Instant;
 import java.util.List;
@@ -17,15 +18,15 @@ import static com.nimbusds.jwt.JWTClaimNames.EXPIRATION_TIME;
 import static com.nimbusds.jwt.JWTClaimNames.ISSUER;
 import static com.nimbusds.jwt.JWTClaimNames.NOT_BEFORE;
 import static com.nimbusds.jwt.JWTClaimNames.SUBJECT;
-import static uk.gov.di.ipv.cri.address.library.domain.verifiablecredential.VerifiableCredentialConstants.ADDRESS_CREDENTIAL_TYPE;
-import static uk.gov.di.ipv.cri.address.library.domain.verifiablecredential.VerifiableCredentialConstants.DI_CONTEXT;
-import static uk.gov.di.ipv.cri.address.library.domain.verifiablecredential.VerifiableCredentialConstants.VC_ADDRESS_KEY;
-import static uk.gov.di.ipv.cri.address.library.domain.verifiablecredential.VerifiableCredentialConstants.VC_CLAIM;
-import static uk.gov.di.ipv.cri.address.library.domain.verifiablecredential.VerifiableCredentialConstants.VC_CONTEXT;
-import static uk.gov.di.ipv.cri.address.library.domain.verifiablecredential.VerifiableCredentialConstants.VC_CREDENTIAL_SUBJECT;
-import static uk.gov.di.ipv.cri.address.library.domain.verifiablecredential.VerifiableCredentialConstants.VC_TYPE;
-import static uk.gov.di.ipv.cri.address.library.domain.verifiablecredential.VerifiableCredentialConstants.VERIFIABLE_CREDENTIAL_TYPE;
-import static uk.gov.di.ipv.cri.address.library.domain.verifiablecredential.VerifiableCredentialConstants.W3_BASE_CONTEXT;
+import static uk.gov.di.ipv.cri.address.api.domain.VerifiableCredentialConstants.ADDRESS_CREDENTIAL_TYPE;
+import static uk.gov.di.ipv.cri.address.api.domain.VerifiableCredentialConstants.DI_CONTEXT;
+import static uk.gov.di.ipv.cri.address.api.domain.VerifiableCredentialConstants.VC_ADDRESS_KEY;
+import static uk.gov.di.ipv.cri.address.api.domain.VerifiableCredentialConstants.VC_CLAIM;
+import static uk.gov.di.ipv.cri.address.api.domain.VerifiableCredentialConstants.VC_CONTEXT;
+import static uk.gov.di.ipv.cri.address.api.domain.VerifiableCredentialConstants.VC_CREDENTIAL_SUBJECT;
+import static uk.gov.di.ipv.cri.address.api.domain.VerifiableCredentialConstants.VC_TYPE;
+import static uk.gov.di.ipv.cri.address.api.domain.VerifiableCredentialConstants.VERIFIABLE_CREDENTIAL_TYPE;
+import static uk.gov.di.ipv.cri.address.api.domain.VerifiableCredentialConstants.W3_BASE_CONTEXT;
 
 public class VerifiableCredentialService {
 

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/IssueCredentialHandlerTest.java
@@ -26,11 +26,11 @@ import software.amazon.awssdk.enhanced.dynamodb.DynamoDbIndex;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
+import uk.gov.di.ipv.cri.address.api.service.VerifiableCredentialService;
 import uk.gov.di.ipv.cri.address.library.helpers.EventProbe;
 import uk.gov.di.ipv.cri.address.library.persistence.DataStore;
 import uk.gov.di.ipv.cri.address.library.persistence.item.AddressSessionItem;
 import uk.gov.di.ipv.cri.address.library.service.ConfigurationService;
-import uk.gov.di.ipv.cri.address.library.service.VerifiableCredentialService;
 
 import java.util.List;
 import java.util.Map;

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/helpers/KMSSignerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/helpers/KMSSignerTest.java
@@ -1,4 +1,4 @@
-package uk.gov.di.ipv.cri.address.library.helpers;
+package uk.gov.di.ipv.cri.address.api.helpers;
 
 import com.amazonaws.services.kms.AWSKMS;
 import com.amazonaws.services.kms.model.MessageType;
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.address.library.helpers.KMSSigner;
 
 import java.nio.ByteBuffer;
 import java.util.Map;

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/helpers/SignClaimSetJwtTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/helpers/SignClaimSetJwtTest.java
@@ -1,4 +1,4 @@
-package uk.gov.di.ipv.cri.address.library.helpers;
+package uk.gov.di.ipv.cri.address.api.helpers;
 
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.crypto.ECDSASigner;
@@ -9,7 +9,8 @@ import com.nimbusds.jwt.SignedJWT;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.di.ipv.cri.address.library.helpers.fixtures.TestFixtures;
+import uk.gov.di.ipv.cri.address.api.helpers.fixtures.TestFixtures;
+import uk.gov.di.ipv.cri.address.library.helpers.SignClaimSetJwt;
 
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/helpers/fixtures/TestFixtures.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/helpers/fixtures/TestFixtures.java
@@ -1,4 +1,4 @@
-package uk.gov.di.ipv.cri.address.library.helpers.fixtures;
+package uk.gov.di.ipv.cri.address.api.helpers.fixtures;
 
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/service/VerifiableCredentialServiceTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/service/VerifiableCredentialServiceTest.java
@@ -1,4 +1,4 @@
-package uk.gov.di.ipv.cri.address.library.service;
+package uk.gov.di.ipv.cri.address.api.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -14,10 +14,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.address.api.helpers.fixtures.TestFixtures;
 import uk.gov.di.ipv.cri.address.library.helpers.SignClaimSetJwt;
-import uk.gov.di.ipv.cri.address.library.helpers.fixtures.TestFixtures;
 import uk.gov.di.ipv.cri.address.library.models.CanonicalAddress;
 import uk.gov.di.ipv.cri.address.library.persistence.item.AddressSessionItem;
+import uk.gov.di.ipv.cri.address.library.service.ConfigurationService;
 
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
@@ -33,9 +34,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.cri.address.library.domain.verifiablecredential.VerifiableCredentialConstants.VC_ADDRESS_KEY;
-import static uk.gov.di.ipv.cri.address.library.domain.verifiablecredential.VerifiableCredentialConstants.VC_CLAIM;
-import static uk.gov.di.ipv.cri.address.library.domain.verifiablecredential.VerifiableCredentialConstants.VC_CREDENTIAL_SUBJECT;
+import static uk.gov.di.ipv.cri.address.api.domain.VerifiableCredentialConstants.VC_ADDRESS_KEY;
+import static uk.gov.di.ipv.cri.address.api.domain.VerifiableCredentialConstants.VC_CLAIM;
+import static uk.gov.di.ipv.cri.address.api.domain.VerifiableCredentialConstants.VC_CREDENTIAL_SUBJECT;
 
 @ExtendWith(MockitoExtension.class)
 class VerifiableCredentialServiceTest implements TestFixtures {
@@ -103,7 +104,7 @@ class VerifiableCredentialServiceTest implements TestFixtures {
                 verifiableCredentialService.generateSignedVerifiableCredentialJwt(
                         SUBJECT, canonicalAddresses);
         JWTClaimsSet generatedClaims = signedJWT.getJWTClaimsSet();
-        assertTrue(signedJWT.verify(new ECDSAVerifier(ECKey.parse(EC_PUBLIC_JWK_1))));
+        assertTrue(signedJWT.verify(new ECDSAVerifier(ECKey.parse(TestFixtures.EC_PUBLIC_JWK_1))));
 
         JsonNode claimsSet = objectMapper.readTree(generatedClaims.toString());
 
@@ -177,7 +178,7 @@ class VerifiableCredentialServiceTest implements TestFixtures {
                                     .get("validUntil")
                                     .asText());
                 });
-        ECDSAVerifier ecVerifier = new ECDSAVerifier(ECKey.parse(EC_PUBLIC_JWK_1));
+        ECDSAVerifier ecVerifier = new ECDSAVerifier(ECKey.parse(TestFixtures.EC_PUBLIC_JWK_1));
         assertTrue(signedJWT.verify(ecVerifier));
     }
 }


### PR DESCRIPTION
Move classes needed for the issue endpoint from lib into
the verifiable credential module in other to make lib more self contained

