### PR TITLE
KBV-363 Update JWKSetFunction to filter on KMS keys deployed in the same stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,4 +70,30 @@ For Dev the following equivalent GitHub secrets:
 | DEV_GH_ACTIONS_ROLE_ARN         | Assumed role IAM ARN |
 | DEV_SIGNING_PROFILE_NAME        | Signing profile name |
 
+## Publishing KMS Public keys
 
+The Address API uses an AWS KMS EC private key to sign verifiable credentials, 
+and an AWS KMS RSA private key to decrypt the Authorization JAR.
+
+The public keys need to be published so that clients:
+* can verify the signature of the verifiable credential, 
+* encrypt the Authorization JAR before sending to this CRI.
+
+The `JWKSetHandler` lambda function publishes these public keys as a JWKSet to `https://${AddressApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/.well-known/jwks.json`.
+
+KMS keys must be marked for publishing by setting the following AWS tags on the KMS resources in the SAM template:
+````
+Tags:
+- Key: "jwkset"
+  Value: "true"
+- Key: "awsStackName"
+  Value: !Sub "${AWS::StackName}"
+````
+
+The `JWKSetHandler` lambda function must be supplied the stack name it is published to the `AWS_STACK_NAME` environment variable:
+
+````
+Environment:
+      Variables:
+        AWS_STACK_NAME: !Sub ${AWS::StackName}
+````

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -431,6 +431,8 @@ Resources:
       Tags:
         - Key: "jwkset"
           Value: "true"
+        - Key: "awsStackName"
+          Value: !Sub "${AWS::StackName}"
 
   SigningKeyAlias:
     Type: AWS::KMS::Alias
@@ -458,6 +460,8 @@ Resources:
       Tags:
         - Key: "jwkset"
           Value: "true"
+        - Key: "awsStackName"
+          Value: !Sub "${AWS::StackName}"
 
   DecryptionKeyAlias:
     Type: AWS::KMS::Alias

--- a/lambdas/jwkset/src/main/java/uk/gov/di/ipv/cri/address/api/handler/EnvironmentService.java
+++ b/lambdas/jwkset/src/main/java/uk/gov/di/ipv/cri/address/api/handler/EnvironmentService.java
@@ -1,0 +1,9 @@
+package uk.gov.di.ipv.cri.address.api.handler;
+
+import java.util.Optional;
+
+public class EnvironmentService {
+    public String getEnvironmentVariableOrThrow(String envVar) {
+        return Optional.ofNullable(System.getenv(envVar)).orElseThrow();
+    }
+}

--- a/lambdas/jwkset/src/main/java/uk/gov/di/ipv/cri/address/api/handler/JWKSetHandler.java
+++ b/lambdas/jwkset/src/main/java/uk/gov/di/ipv/cri/address/api/handler/JWKSetHandler.java
@@ -1,7 +1,5 @@
 package uk.gov.di.ipv.cri.address.api.handler;
 
-import com.amazonaws.services.kms.model.KeyListEntry;
-import com.amazonaws.services.kms.model.KeyMetadata;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
@@ -16,23 +14,18 @@ import software.amazon.lambda.powertools.metrics.Metrics;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-
-import static java.util.stream.Collectors.toList;
 
 public class JWKSetHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
-    public static final String DEFAULT_TAG_FOR_JWKSET_EXPORT = "jwkset";
+    private final JWKSetService jwkSetService;
 
-    private final KMSService kmsService;
-
-    public JWKSetHandler(KMSService kmsService) {
-        this.kmsService = kmsService;
+    public JWKSetHandler(JWKSetService jwkSetService) {
+        this.jwkSetService = jwkSetService;
     }
 
     public JWKSetHandler() {
-        kmsService = new KMSService();
+        this.jwkSetService = new JWKSetService();
     }
 
     @Override
@@ -41,44 +34,13 @@ public class JWKSetHandler
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
 
-        // a tag controls which public JWKs are shown
-        String tagForPublish = getTagForPublish();
-        List<JWK> jwks =
-                getKMSKeyIds().stream()
-                        .map(KeyListEntry::getKeyId)
-                        .filter(keyId -> findByTag(keyId, tagForPublish))
-                        .filter(keyId -> findEnabled(keyId))
-                        .map(keyId -> mapToJWK(keyId))
-                        .collect(toList());
-
+        List<JWK> jwks = jwkSetService.getJWKs();
+        JWKSet jwkSet = new JWKSet(jwks);
         APIGatewayProxyResponseEvent apiGatewayProxyResponseEvent =
                 new APIGatewayProxyResponseEvent();
         apiGatewayProxyResponseEvent.setStatusCode(HttpStatus.SC_OK);
-        apiGatewayProxyResponseEvent.setBody(new JWKSet(jwks).toString());
+        apiGatewayProxyResponseEvent.setBody(jwkSet.toString());
         apiGatewayProxyResponseEvent.setHeaders(Map.of(Header.CONTENT_TYPE, JWKSet.MIME_TYPE));
         return apiGatewayProxyResponseEvent;
-    }
-
-    private List<KeyListEntry> getKMSKeyIds() {
-        return kmsService.getKeys();
-    }
-
-    private JWK mapToJWK(String keyId) {
-        return kmsService.getJWK(keyId);
-    }
-
-    private boolean findByTag(String keyId, String getTagForPublish) {
-        return kmsService.getTags(keyId).stream()
-                .anyMatch(t -> getTagForPublish.equals(t.getTagKey()));
-    }
-
-    private String getTagForPublish() {
-        return Optional.ofNullable(System.getenv("TAG_FOR_JWKSET_EXPORT"))
-                .orElse(DEFAULT_TAG_FOR_JWKSET_EXPORT);
-    }
-
-    private boolean findEnabled(String keyId) {
-        KeyMetadata keyMetadata = kmsService.getMetadata(keyId);
-        return "Enabled".equals(keyMetadata.getKeyState());
     }
 }

--- a/lambdas/jwkset/src/main/java/uk/gov/di/ipv/cri/address/api/handler/JWKSetService.java
+++ b/lambdas/jwkset/src/main/java/uk/gov/di/ipv/cri/address/api/handler/JWKSetService.java
@@ -1,0 +1,68 @@
+package uk.gov.di.ipv.cri.address.api.handler;
+
+import com.amazonaws.services.kms.model.KeyMetadata;
+import com.amazonaws.services.kms.model.Tag;
+import com.nimbusds.jose.jwk.JWK;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static java.util.stream.Collectors.toList;
+
+public class JWKSetService {
+
+    public static final String ENV_VAR_NAME_CLOUDFORMATION_STACK = "AWS_STACK_NAME";
+
+    private final KMSService kmsService;
+
+    private final EnvironmentService environmentService;
+
+    public JWKSetService() {
+        this.environmentService = new EnvironmentService();
+        this.kmsService = new KMSService();
+    }
+
+    public JWKSetService(KMSService kmsService, EnvironmentService environmentService) {
+        this.kmsService = kmsService;
+        this.environmentService = environmentService;
+    }
+
+    public List<JWK> getJWKs() {
+        Set<Tag> tagsToMatch = Set.of(getStackNameTagForPublish(), getJWKSetTagForPublish());
+        return getKMSKeyIds().stream()
+                .filter(keyId -> matchOnTags(keyId, tagsToMatch))
+                .filter(this::findEnabled)
+                .map(this::mapToJWK)
+                .collect(toList());
+    }
+
+    private List<String> getKMSKeyIds() {
+        return kmsService.getKeyIds();
+    }
+
+    private JWK mapToJWK(String keyId) {
+        return kmsService.getJWK(keyId);
+    }
+
+    protected boolean matchOnTags(String keyId, Set<Tag> tagsForPublish) {
+        Set<Tag> mutableCopy = new HashSet<>(tagsForPublish);
+        Set<Tag> tags = kmsService.getTags(keyId);
+        return !mutableCopy.retainAll(tags);
+    }
+
+    private Tag getStackNameTagForPublish() {
+        String stackNameForThisFunction =
+                environmentService.getEnvironmentVariableOrThrow(ENV_VAR_NAME_CLOUDFORMATION_STACK);
+        return new Tag().withTagKey("awsStackName").withTagValue(stackNameForThisFunction);
+    }
+
+    private Tag getJWKSetTagForPublish() {
+        return new Tag().withTagKey("jwkset").withTagValue("true");
+    }
+
+    private boolean findEnabled(String keyId) {
+        KeyMetadata keyMetadata = kmsService.getMetadata(keyId);
+        return "Enabled".equals(keyMetadata.getKeyState());
+    }
+}

--- a/lambdas/jwkset/src/test/java/uk/gov/di/ipv/cri/address/api/handler/JWKSetHandlerTest.java
+++ b/lambdas/jwkset/src/test/java/uk/gov/di/ipv/cri/address/api/handler/JWKSetHandlerTest.java
@@ -1,11 +1,9 @@
 package uk.gov.di.ipv.cri.address.api.handler;
 
-import com.amazonaws.services.kms.model.KeyListEntry;
-import com.amazonaws.services.kms.model.KeyMetadata;
-import com.amazonaws.services.kms.model.Tag;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.KeyUse;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
@@ -14,38 +12,31 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.http.Header;
 
+import java.text.ParseException;
 import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class JWKSetHandlerTest {
 
-    @Mock private KMSService kmsService;
-
-    @Mock private KeyListEntry keyListEntry;
-
-    @Mock private KeyMetadata keyMetadata;
-
-    @Mock private Tag tag;
+    @Mock JWKSetService jwkSetService;
 
     @Test
-    void shouldFilterToFindTaggedAndEnabledRSAKMSKey() throws JOSEException {
-        String keyId = "a kms key id";
-        when(keyListEntry.getKeyId()).thenReturn(keyId);
-        when(kmsService.getKeys()).thenReturn(List.of(keyListEntry));
-        when(kmsService.getTags(keyId)).thenReturn(List.of(tag));
-        when(tag.getTagKey()).thenReturn("jwkset");
-        when(kmsService.getMetadata(keyId)).thenReturn(keyMetadata);
-        when(keyMetadata.getKeyState()).thenReturn("Enabled");
-        when(kmsService.getJWK(keyId)).thenReturn(createRSAJWK());
-
+    void shouldAddJWKsToAJWKSetAndReturn() throws JOSEException, ParseException {
+        JWK sampleJWK = createRSAJWK();
+        when(jwkSetService.getJWKs()).thenReturn(List.of(sampleJWK));
         APIGatewayProxyResponseEvent responseEvent =
-                new JWKSetHandler(kmsService).handleRequest(null, null);
+                new JWKSetHandler(jwkSetService).handleRequest(null, null);
         assertEquals(HttpStatus.SC_OK, responseEvent.getStatusCode());
+        assertEquals(JWKSet.MIME_TYPE, responseEvent.getHeaders().get(Header.CONTENT_TYPE));
+        JWKSet jwkSet = JWKSet.parse(responseEvent.getBody());
+        assertTrue(jwkSet.containsJWK(sampleJWK));
     }
 
     private JWK createRSAJWK() throws JOSEException {

--- a/lambdas/jwkset/src/test/java/uk/gov/di/ipv/cri/address/api/handler/JWKSetServiceTest.java
+++ b/lambdas/jwkset/src/test/java/uk/gov/di/ipv/cri/address/api/handler/JWKSetServiceTest.java
@@ -1,0 +1,100 @@
+package uk.gov.di.ipv.cri.address.api.handler;
+
+import com.amazonaws.services.kms.model.KeyMetadata;
+import com.amazonaws.services.kms.model.Tag;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toSet;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.cri.address.api.handler.JWKSetService.ENV_VAR_NAME_CLOUDFORMATION_STACK;
+
+@ExtendWith(MockitoExtension.class)
+class JWKSetServiceTest {
+
+    @Mock private EnvironmentService environmentService;
+
+    @Mock private KMSService kmsService;
+
+    @Mock private KeyMetadata keyMetadata;
+
+    @Test
+    void shouldMatchAKMSKeyByTagsAndEnabled() throws JOSEException {
+
+        String keyId = "a kms key id";
+
+        when(environmentService.getEnvironmentVariableOrThrow(ENV_VAR_NAME_CLOUDFORMATION_STACK))
+                .thenReturn("a stack name");
+
+        when(kmsService.getKeyIds()).thenReturn(List.of(keyId));
+        Tag tag1 = new Tag().withTagKey("jwkset").withTagValue("true");
+        Tag tag2 = new Tag().withTagKey("awsStackName").withTagValue("a stack name");
+
+        when(kmsService.getTags(keyId)).thenReturn(Set.of(tag1, tag2));
+        when(kmsService.getMetadata(keyId)).thenReturn(keyMetadata);
+        when(keyMetadata.getKeyState()).thenReturn("Enabled");
+        JWK jwk = createRSAJWK(keyId);
+        when(kmsService.getJWK(keyId)).thenReturn(jwk);
+
+        JWKSetService jwkSetService = new JWKSetService(kmsService, environmentService);
+        List<JWK> jwks = jwkSetService.getJWKs();
+        assertEquals(1, jwks.size());
+        assertSame(jwks.get(0), jwk);
+    }
+
+    @ParameterizedTest
+    @MethodSource("generateData")
+    void name(boolean expectMatch, Set<Tag> tagsForPublish, Set<Tag> tagsOnKey) {
+        when(kmsService.getTags("a key id")).thenReturn(tagsOnKey);
+        boolean result =
+                new JWKSetService(kmsService, null).matchOnTags("a key id", tagsForPublish);
+        assertEquals(expectMatch, result);
+    }
+
+    private static Stream<Arguments> generateData() {
+        return Stream.of(
+                Arguments.of(
+                        true,
+                        toTags(Map.of("a", "b", "c", "d")),
+                        toTags(Map.of("a", "b", "c", "d"))),
+                Arguments.of(true, toTags(Map.of("a", "b")), toTags(Map.of("a", "b", "c", "d"))),
+                Arguments.of(
+                        false,
+                        toTags(Map.of("a", "b", "c", "d")),
+                        toTags(Map.of("a", "b", "c", "e"))),
+                Arguments.of(false, toTags(Map.of("a", "b", "c", "d")), toTags(Map.of("a", "b"))));
+    }
+
+    private static Set<Tag> toTags(Map<String, String> input) {
+        Set<Map.Entry<String, String>> entries = input.entrySet();
+        return entries.stream()
+                .map(e -> new Tag().withTagKey(e.getKey()).withTagValue(e.getValue()))
+                .collect(toSet());
+    }
+
+    private JWK createRSAJWK(String keyId) throws JOSEException {
+        RSAKey jwk =
+                new RSAKeyGenerator(2048)
+                        .keyUse(KeyUse.SIGNATURE) // indicate the intended use of the key
+                        .keyID(keyId) // give the key a unique ID
+                        .generate();
+        return jwk.toPublicJWK();
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Update JWKSetFunction to filter on KMS keys deployed in the same stack.

This is necessary to avoid IAM permission errors on reading KMS public keys outside the JWKSetFunction's owning stack.

### What changed

* Add an extra "stack name" tag on the KMS keys
* Evaluate that the stack name tag matches the JWKSetFunction's stack name
* Add a README.md section to explain how to configure KMS keys
* Move a bunch of methods out of the function handler and into a new JWKSetService

<!-- Describe the changes in detail - the "what"-->

### Why did it change

The jwkset url wasn't working, as the fn was trying to read the public keys outside this stack, for which there was no IAM policy.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-363](https://govukverify.atlassian.net/browse/KBV-363)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed


### Testing

- [ ] tested on a personal stack