### PR TITLE
[KBV-358] Remove secondary indexes on the session table

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -517,23 +517,12 @@ Resources:
       AttributeDefinitions:
         - AttributeName: "sessionId"
           AttributeType: "S"
-        - AttributeName: "authorizationCode"
-          AttributeType: "S"
         - AttributeName: "accessToken"
           AttributeType: "S"
       KeySchema:
         - AttributeName: "sessionId"
           KeyType: "HASH"
       GlobalSecondaryIndexes:
-        - IndexName: "authorizationCode-index"
-          KeySchema:
-            - AttributeName: "authorizationCode"
-              KeyType: "HASH"
-          Projection:
-            NonKeyAttributes:
-              - "sessionId"
-              - "redirectUri"
-            ProjectionType: "INCLUDE"
         - IndexName: "access-token-index"
           KeySchema:
             - AttributeName: "accessToken"


### PR DESCRIPTION
PR 1 of 4 to recreate secondary indexes on the Session Table to handle correct projections