### PR TITLE
[KBV-358] Re-add secondary index for access token on session table

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -576,7 +576,7 @@ Resources:
       Value: !Sub session-${AWS::StackName}
       Type: String
       Description: session dynamodb table name
-      
+
   ParameterAddressItemTableName:
     Type: AWS::SSM::Parameter
     Properties:

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -524,24 +524,6 @@ Resources:
       KeySchema:
         - AttributeName: "sessionId"
           KeyType: "HASH"
-      GlobalSecondaryIndexes:
-        - IndexName: "authorizationCode-index"
-          KeySchema:
-            - AttributeName: "authorizationCode"
-              KeyType: "HASH"
-          Projection:
-            NonKeyAttributes:
-              - "sessionId"
-              - "redirectUri"
-            ProjectionType: "INCLUDE"
-        - IndexName: "access-token-index"
-          KeySchema:
-            - AttributeName: "accessToken"
-              KeyType: "HASH"
-          Projection:
-            NonKeyAttributes:
-              - "sessionId"
-            ProjectionType: "INCLUDE"
       TimeToLiveSpecification:
         AttributeName: expiry-date
         Enabled: true

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -524,6 +524,16 @@ Resources:
       KeySchema:
         - AttributeName: "sessionId"
           KeyType: "HASH"
+      GlobalSecondaryIndexes:
+        - IndexName: "access-token-index"
+          KeySchema:
+            - AttributeName: "accessToken"
+              KeyType: "HASH"
+          Projection:
+            NonKeyAttributes:
+              - "sessionId"
+              - "subject"
+            ProjectionType: "INCLUDE"
       TimeToLiveSpecification:
         AttributeName: expiry-date
         Enabled: true

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -517,8 +517,6 @@ Resources:
       AttributeDefinitions:
         - AttributeName: "sessionId"
           AttributeType: "S"
-        - AttributeName: "authorizationCode"
-          AttributeType: "S"
         - AttributeName: "accessToken"
           AttributeType: "S"
       KeySchema:


### PR DESCRIPTION
PR 3 of 4 to recreate secondary indexes on the Session Table to handle correct projections