### PR TITLE
KBV-358 - Return complete session item when retrieving by auth code

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/SessionService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/SessionService.java
@@ -94,7 +94,9 @@ public class SessionService {
     }
 
     public SessionItem getSessionByAuthorisationCode(String authCode) {
-        return listUtil.getOneItemOrThrowError(
-                dataStore.getItemByIndex(SessionItem.AUTHORIZATION_CODE_INDEX, authCode));
+        SessionItem sessionItem =
+                listUtil.getOneItemOrThrowError(
+                        dataStore.getItemByIndex(SessionItem.AUTHORIZATION_CODE_INDEX, authCode));
+        return getSession(sessionItem.getSessionId().toString());
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/address/library/service/SessionServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/address/library/service/SessionServiceTest.java
@@ -91,6 +91,7 @@ class SessionServiceTest {
         when(mockListUtil.getOneItemOrThrowError(items)).thenReturn(item);
         when(mockDataStore.getItemByIndex(SessionItem.AUTHORIZATION_CODE_INDEX, authCodeValue))
                 .thenReturn(items);
+        when(mockDataStore.getItem(item.getSessionId().toString())).thenReturn(item);
 
         SessionItem sessionItem = sessionService.getSessionByAuthorisationCode(authCodeValue);
         assertThat(item.getSessionId(), equalTo(sessionItem.getSessionId()));


### PR DESCRIPTION
### What changed
SessionService updated to return all fields of the SessionItem when retrieving by auth code
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The current projection on the auth code index contains insufficient to update the SessionItem after it has been retrieved.

### Issue tracking
- [KBV-358](https://govukverify.atlassian.net/browse/KBV-358)
