### PR TITLE
KBV-360 transcode KMS DER sigs to concat format

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -126,9 +126,9 @@ Mappings:
 
   IPVCore1RedirectURIMapping:
     Environment:
-      staging: "https://staging-di-ipv-core-front.london.cloudapps.digital/credential-issuer/callback"
-      integration: "https://integration-di-ipv-core-front.london.cloudapps.digital/credential-issuer/callback"
-      production: "https://di-ipv-core-front.london.cloudapps.digital/credential-issuer/callback"
+      staging: "https://staging-di-ipv-core-front.london.cloudapps.digital/credential-issuer/callback?id=debugAddress"
+      integration: "https://integration-di-ipv-core-front.london.cloudapps.digital/credential-issuer/callback?id=address"
+      production: "https://di-ipv-core-front.london.cloudapps.digital/credential-issuer/callback?id=address"
 
   OrdnanceSurveyAPIURLMapping:
     Environment:

--- a/lib/src/test/java/uk/gov/di/ipv/cri/address/library/service/JWTVerifierTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/address/library/service/JWTVerifierTest.java
@@ -181,28 +181,6 @@ class JWTVerifierTest {
     }
 
     @Test
-    void shouldValidateJWTSignedWithRSAKey()
-            throws JOSEException, InvalidKeySpecException, NoSuchAlgorithmException {
-        Map<String, String> clientConfigMap = getSSMClientConfig();
-        SignedJWT signedJWT =
-                new SignedJWT(
-                        new JWSHeader.Builder(JWSAlgorithm.RS256).build(),
-                        new JWTClaimsSet.Builder()
-                                .issuer("https://dev.core.ipv.account.gov.uk")
-                                .notBeforeTime(Date.from(now))
-                                .audience("https://address.cri.account.gov.uk")
-                                .subject(UUID.randomUUID().toString())
-                                .expirationTime(Date.from(now.plus(1, ChronoUnit.HOURS)))
-                                .build());
-
-        RSASSASigner rsaSigner = new RSASSASigner(getPrivateKey());
-        signedJWT.sign(rsaSigner);
-
-        assertDoesNotThrow(
-                () -> jwtVerifier.verifyJWT(clientConfigMap, signedJWT, getRequiredClaims()));
-    }
-
-    @Test
     void shouldValidateJWTSignedWithECKey() throws JOSEException, ParseException {
         Map<String, String> clientConfigMap = getECSSMClientConfig();
         SignedJWT signedJWT =


### PR DESCRIPTION
## Proposed changes

The EC signatures produced by AWS KMS are in DER format. The Nimbus lib we're using to verify the signatures needs them in concat format.

This is a [copy of the code passport-back](https://github.com/alphagov/di-ipv-cri-uk-passport-back/pull/105/commits/8573927bad3deb68f57bece09e1fc32753222d8e) uses to transcode a DER format signature to concat format.

👉 Also.. fix the redirect uri to a form that IPV Core expects.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-360](https://govukverify.atlassian.net/browse/KBV-360)