### PR TITLE
BAU Remove regex on auth jar

### DIFF
--- a/infrastructure/lambda/api.yaml
+++ b/infrastructure/lambda/api.yaml
@@ -311,8 +311,6 @@ components:
           example: "ipv-core-stub"
         request:
           type: "string"
-          pattern: "[a-zA-Z0-9_=]+\\.[a-zA-Z0-9_=]+\\.[a-zA-Z0-9_\\-\\+\\/=]+"
-          example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0dCIsImlhdCI6MTUxNjIzOTAyMn0.SbcN-ywpLObhMbbaMCtW1Un8LYhQzHsEth9LvTk4oQQ"
     AuthorizationResponse:
       required:
         - "redirect_uri"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

API gateway intermittently fails validation on the `/session` request when the [JWE](https://datatracker.ietf.org/doc/html/rfc7516) sent in the Authz JAR fails a regex check:
````
(5081812f-4dfc-46a0-9172-c9b813cac751) Request body does not match model schema for content type application/json: [ECMA 262 regex "[a-zA-Z0-9_=]+\.[a-zA-Z0-9_=]+\.[a-zA-Z0-9_\-\+\/=]+" does not match input string "eyJjdHkiOiJKV1QiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiUlNBLU9BRVAtMjU2In0.FDFE5bZ74Byg1AhuQNDNM9X7INyt2tJNJHhijvJtGNTB-GGtCSxnOcUwqlJNMKImd2BKl813P2F58aU17ljOzM0-fXqb8M3_gWxFg8ZmVMYNo2FHbcN7ptoSg3A2WaWAEYSiUdUpJzU2_Uk-91DZwjpsAZUj0BCTemiSwKZOpW9kQoPPEgS27alS_Ia5RWkr8w9C_EUgFpdadUkP2xWP76j7uvRX_fnlGMwfxkPkhjlSIMHlZ-taL_FxMTiezcn7urcUyQAqma_MuN3NgG50qAnjbn2oVLsYJ4wEUfDFibAQMG4EUBvwQ6LDEsIkXALsCtkC2mkE3OFnUxXpSDLgag.Zbgg1-5zZ-GkcSwn.xta5fFTGaaBvyd720dh_sCO2mm3c_Ntb8W5-HJg7EK48_4tTkfvW654Z4gmw99NiWKNOXVqVYb0iSaZ16oOiIbaOqkLgI8ZqkrvWmslWgjjp1YjkPYn9lI_wtlVWQu3oRpc5DAHkdsQCzZIlYyUmGHBEHJIFrpJ8mRYZfHKSvWh14gnxI2YhvUwEsTkZF8Jgn-3M9qoDYXixw2hrjFhpFsRwamHKwwJE_18-xkGVXc8M9mNE6uoYWJ210x1RTu-CQO3HmpTuclZhDhRRGJLENM1nRYZWNXK6aDnRgdJ4PvQC5bD0ZLNUx4626DFtyz6XTGLXGs0cGNz65bH1nr8GOkwpIeTOsW21lNctLbs5HDqJPy9HrkDN1vzcXKUWNItus1FfpTwu7bRhKFkB5jUq38dcFTmAXzY8EoNp [TRUNCATED]

````
This regex matches most of the time, but if I keep retrying to create sessions, I get this error ☝️ in about 1/5 of cases.

This PR removes this regex validation - we decrypt the JAR and validate its structure within the session lambda anyway.