### PR TITLE
[KBV-506] - Refactor Address CRI to use new /authorization endpoint for returning authorization code

### DIFF
--- a/doc/api.puml
+++ b/doc/api.puml
@@ -46,7 +46,7 @@ activate api
 
 api -> api: create authorization_code
 api -> db: write address, authorization_code
-return 201
+return 204 (NO_CONTENT)
 
 fe -> api: POST /authorization
 activate api

--- a/doc/api.puml
+++ b/doc/api.puml
@@ -33,7 +33,7 @@ return session-id
 
 fe-[#blue]>fe: display post code page
 
-fe -> api: POST /postcode-lookup
+fe -> api: GET /postcode-lookup
 activate api
 api->pcl: /postcode-lookup
 api<--pcl: addresses
@@ -41,20 +41,27 @@ return addresses
 
 fe-[#blue]>fe: display addresses
 
-fe->api: /address
+fe->api: POST /address
 activate api
 
 api -> api: create authorization_code
 api -> db: write address, authorization_code
-return 204 (authorization_code)
+return 201
 
-core <[#green]- fe: /callback\n(authorization code)
+fe -> api: POST /authorization
+activate api
+api -> api: get authorization_code from session-id
+db -> api: read authorization_code
+api -> fe: authorization_code
+destroy api
+
+core <[#green]- fe: /callback\n(authorization_code)
 destroy fe
 == Oauth return ==
 
 
 
-core -[#green]> api: /token (auth code)
+core -[#green]> api: /token (authorization_code)
 activate api
 api -> api: create token
 api -> db: write token

--- a/infrastructure/lambda/api.yaml
+++ b/infrastructure/lambda/api.yaml
@@ -143,6 +143,38 @@ paths:
         contentHandling: "CONVERT_TO_TEXT"
         type: "aws_proxy"
 
+  /authorization:
+    get:
+      parameters:
+        - $ref: "#/components/parameters/SessionHeader"
+      responses:
+        "200":
+          description: "200 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthorizationResponse"
+        "400":
+          description: "400 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: "500 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+      x-amazon-apigateway-request-validator: "Validate both"
+      x-amazon-apigateway-integration:
+        type: "aws_proxy"
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${AuthorizationFunction.Arn}/invocations"
+        passthroughBehavior: "when_no_match"
+
+
   /token:
     post:
       requestBody:

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -340,6 +340,34 @@ Resources:
               Resource:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/clients/*"
 
+  AuthorizationFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../../common-lambdas/authorization/build/distributions/authorization.zip
+      Handler: uk.gov.di.ipv.cri.common.api.handler.AuthorizationHandler::handleRequest
+      Environment:
+        Variables:
+          POWERTOOLS_METRICS_NAMESPACE: di-ipv-cri-address-api
+          POWERTOOLS_SERVICE_NAME: di-ipv-cri-address-api-authorization
+      Policies:
+        - AWSLambdaBasicExecutionRole
+        - AWSXrayWriteOnlyAccess
+        - DynamoDBReadPolicy:
+            TableName: !Ref SessionTable
+        - Statement:
+            - Effect: Allow
+              Action:
+                - ssm:GetParameter
+              Resource:
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/SessionTableName"
+        - Statement:
+            - Effect: Allow
+              Action:
+                - ssm:GetParametersByPath
+              Resource:
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/clients/*"
+
+
   AccessTokenFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -702,6 +730,13 @@ Resources:
     Properties:
       Action: lambda:InvokeFunction
       FunctionName: !GetAtt AccessTokenFunction.Arn
+      Principal: apigateway.amazonaws.com
+
+  AuthorizationFunctionPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !GetAtt AuthorizationFunction.Arn
       Principal: apigateway.amazonaws.com
 
   SessionFunctionPermission:

--- a/lambdas/address/src/main/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandler.java
+++ b/lambdas/address/src/main/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandler.java
@@ -15,7 +15,6 @@ import uk.gov.di.ipv.cri.address.library.exception.AddressProcessingException;
 import uk.gov.di.ipv.cri.address.library.service.AddressService;
 import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.cri.common.library.domain.AuditEventTypes;
-import uk.gov.di.ipv.cri.common.library.domain.AuthorizationResponse;
 import uk.gov.di.ipv.cri.common.library.exception.SessionExpiredException;
 import uk.gov.di.ipv.cri.common.library.exception.SessionNotFoundException;
 import uk.gov.di.ipv.cri.common.library.exception.SqsException;
@@ -88,8 +87,7 @@ public class AddressHandler
                 sessionService.createAuthorizationCode(session);
 
                 eventProbe.counterMetric(LAMBDA_NAME);
-                return ApiGatewayResponseGenerator.proxyJsonResponse(
-                        HttpStatusCode.CREATED, new AuthorizationResponse(session));
+                return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatusCode.CREATED, "");
             }
 
             // If we don't have at least one address, do not save

--- a/lambdas/address/src/main/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandler.java
+++ b/lambdas/address/src/main/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandler.java
@@ -87,7 +87,7 @@ public class AddressHandler
                 sessionService.createAuthorizationCode(session);
 
                 eventProbe.counterMetric(LAMBDA_NAME);
-                return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatusCode.CREATED, "");
+                return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatusCode.NO_CONTENT, "");
             }
 
             // If we don't have at least one address, do not save

--- a/lambdas/address/src/main/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandler.java
+++ b/lambdas/address/src/main/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandler.java
@@ -15,7 +15,6 @@ import uk.gov.di.ipv.cri.address.library.exception.AddressProcessingException;
 import uk.gov.di.ipv.cri.address.library.service.AddressService;
 import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.cri.common.library.domain.AuditEventType;
-import uk.gov.di.ipv.cri.common.library.domain.AuthorizationResponse;
 import uk.gov.di.ipv.cri.common.library.exception.SessionExpiredException;
 import uk.gov.di.ipv.cri.common.library.exception.SessionNotFoundException;
 import uk.gov.di.ipv.cri.common.library.exception.SqsException;

--- a/lambdas/address/src/test/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandlerTest.java
+++ b/lambdas/address/src/test/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandlerTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.http.HttpStatusCode;
 import uk.gov.di.ipv.cri.address.library.exception.AddressProcessingException;
 import uk.gov.di.ipv.cri.address.library.persistence.item.AddressItem;
 import uk.gov.di.ipv.cri.address.library.service.AddressService;
@@ -103,7 +104,7 @@ class AddressHandlerTest {
 
         APIGatewayProxyResponseEvent responseEvent =
                 addressHandler.handleRequest(apiGatewayProxyRequestEvent, null);
-        assertEquals(201, responseEvent.getStatusCode());
+        assertEquals(HttpStatusCode.NO_CONTENT, responseEvent.getStatusCode());
 
         verify(mockSessionService).createAuthorizationCode(sessionItem);
         verify(eventProbe).counterMetric("address");
@@ -122,7 +123,7 @@ class AddressHandlerTest {
 
         APIGatewayProxyResponseEvent responseEvent =
                 addressHandler.handleRequest(apiGatewayProxyRequestEvent, null);
-        assertEquals(200, responseEvent.getStatusCode());
+        assertEquals(HttpStatusCode.OK, responseEvent.getStatusCode());
 
         verifyNoInteractions(eventProbe);
     }

--- a/lambdas/address/src/test/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandlerTest.java
+++ b/lambdas/address/src/test/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandlerTest.java
@@ -30,8 +30,14 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.notNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AddressHandlerTest {

--- a/lambdas/address/src/test/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandlerTest.java
+++ b/lambdas/address/src/test/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandlerTest.java
@@ -3,7 +3,6 @@ package uk.gov.di.ipv.cri.address.api.handler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.Level;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,7 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -80,7 +79,7 @@ class AddressHandlerTest {
     }
 
     @Test
-    void ValidSaveReturnsAuthorizationCode()
+    void ValidSaveGeneratesAuthorizationCode()
             throws JsonProcessingException, AddressProcessingException, SessionExpiredException,
                     SessionNotFoundException, SqsException {
 
@@ -105,10 +104,6 @@ class AddressHandlerTest {
         APIGatewayProxyResponseEvent responseEvent =
                 addressHandler.handleRequest(apiGatewayProxyRequestEvent, null);
         assertEquals(201, responseEvent.getStatusCode());
-
-        assertEquals(
-                responseEvent.getBody(),
-                new ObjectMapper().writeValueAsString(authorizationResponse));
 
         verify(mockSessionService).createAuthorizationCode(sessionItem);
         verify(eventProbe).counterMetric("address");

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/service/VerifiableCredentialServiceTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/service/VerifiableCredentialServiceTest.java
@@ -3,6 +3,8 @@ package uk.gov.di.ipv.cri.address.api.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.crypto.ECDSASigner;
 import com.nimbusds.jose.crypto.ECDSAVerifier;
@@ -48,7 +50,10 @@ class VerifiableCredentialServiceTest implements TestFixtures {
     public static final String COUNTRY_CODE = "GB";
     public static final LocalDate VALID_FROM = LocalDate.of(2010, 02, 26);
     public static final LocalDate VALID_UNTIL = LocalDate.of(2021, 01, 16);
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper =
+            new ObjectMapper()
+                    .registerModule(new Jdk8Module())
+                    .registerModule(new JavaTimeModule());
     @Mock private ConfigurationService mockConfigurationService;
 
     @BeforeEach
@@ -61,7 +66,8 @@ class VerifiableCredentialServiceTest implements TestFixtures {
     void shouldReturnAVerifiedCredentialWhenGivenCanonicalAddresses() throws JOSEException {
         SignedJWTFactory mockSignedClaimSetJwt = mock(SignedJWTFactory.class);
         var verifiableCredentialService =
-                new VerifiableCredentialService(mockSignedClaimSetJwt, mockConfigurationService);
+                new VerifiableCredentialService(
+                        mockSignedClaimSetJwt, mockConfigurationService, objectMapper);
 
         when(mockConfigurationService.getVerifiableCredentialIssuer())
                 .thenReturn("address-cri-issue");
@@ -93,7 +99,8 @@ class VerifiableCredentialServiceTest implements TestFixtures {
 
         SignedJWTFactory signedJwtFactory = new SignedJWTFactory(new ECDSASigner(getPrivateKey()));
         var verifiableCredentialService =
-                new VerifiableCredentialService(signedJwtFactory, mockConfigurationService);
+                new VerifiableCredentialService(
+                        signedJwtFactory, mockConfigurationService, objectMapper);
 
         SignedJWT signedJWT =
                 verifiableCredentialService.generateSignedVerifiableCredentialJwt(

--- a/lambdas/postcode-lookup/src/test/java/uk/gov/di/ipv/cri/address/api/handler/PostcodeLookupHanderTest.java
+++ b/lambdas/postcode-lookup/src/test/java/uk/gov/di/ipv/cri/address/api/handler/PostcodeLookupHanderTest.java
@@ -25,7 +25,11 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNotNull;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,10 +4,11 @@ rootProject.name = "di-ipv-cri-address-api"
 include "common-lib"
 
 // Common lambdas
-include "session", "accesstoken", "jwkset"
+include "session", "accesstoken", "jwkset", "authorization"
 project(':session').projectDir = new File('./common-lambdas/session')
 project(":accesstoken").projectDir = new File('./common-lambdas/accesstoken')
 project(':jwkset').projectDir = new File('./common-lambdas/jwkset')
+project(':authorization').projectDir = new File('./common-lambdas/authorization')
 
 // CRI specific lib
 include 'lib'


### PR DESCRIPTION
## Proposed changes

### What changed

- Update to move the authorization code response away from the /address endpoint and utilised /authorization common lambda
- Updated documentation
- Updated references to common submodules

### Why did it change

All CRIs now use a series of common lambdas and endpoints.
The Address CRI was returning the authorization code as part of the response to /address, which does not match the new patterns, nor the correct OAuth flow

### Issue tracking

- [KBV-506](https://govukverify.atlassian.net/browse/KBV-506)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed