### PR TITLE
BAU - update to use latest common ConfigurationService

### DIFF
--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/handler/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/handler/IssueCredentialHandler.java
@@ -5,6 +5,8 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.ParseException;
@@ -59,15 +61,20 @@ public class IssueCredentialHandler
     }
 
     public IssueCredentialHandler() {
+        ConfigurationService configurationService = new ConfigurationService();
+        ObjectMapper objectMapper =
+                new ObjectMapper()
+                        .registerModule(new Jdk8Module())
+                        .registerModule(new JavaTimeModule());
         this.verifiableCredentialService = getVerifiableCredentialService();
-        this.addressService = new AddressService();
+        this.addressService = new AddressService(configurationService, objectMapper);
         this.sessionService = new SessionService();
         this.eventProbe = new EventProbe();
         this.auditService =
                 new AuditService(
                         SqsClient.builder().build(),
-                        new ConfigurationService(),
-                        new ObjectMapper(),
+                        configurationService,
+                        objectMapper,
                         Clock.systemUTC());
     }
 

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/service/VerifiableCredentialService.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/service/VerifiableCredentialService.java
@@ -60,10 +60,6 @@ public class VerifiableCredentialService {
     public SignedJWT generateSignedVerifiableCredentialJwt(
             String subject, List<CanonicalAddress> canonicalAddresses) throws JOSEException {
         var now = Instant.now();
-        ObjectMapper mapper =
-                new ObjectMapper()
-                        .registerModule(new Jdk8Module())
-                        .registerModule(new JavaTimeModule());
 
         var claimsSet =
                 new JWTClaimsSet.Builder()

--- a/lambdas/postcode-lookup/src/main/java/uk/gov/di/ipv/cri/address/api/service/PostcodeLookupService.java
+++ b/lambdas/postcode-lookup/src/main/java/uk/gov/di/ipv/cri/address/api/service/PostcodeLookupService.java
@@ -37,8 +37,8 @@ public class PostcodeLookupService {
     Logger log = LogManager.getLogger();
 
     public PostcodeLookupService() {
-        configurationService = new ConfigurationService();
-        client =
+        this.configurationService = new ConfigurationService();
+        this.client =
                 HttpClient.newBuilder()
                         .version(HttpClient.Version.HTTP_2)
                         .connectTimeout(Duration.ofSeconds(10))
@@ -72,11 +72,13 @@ public class PostcodeLookupService {
                                     SdkHttpFullRequest.builder()
                                             .uri(
                                                     new URI(
-                                                            configurationService
-                                                                    .getOsPostcodeAPIUrl()))
+                                                            configurationService.getParameterValue(
+                                                                    "OrdnanceSurveyAPIURL")))
                                             .appendRawQueryParameter("postcode", postcode)
                                             .appendRawQueryParameter(
-                                                    "key", configurationService.getOsApiKey())
+                                                    "key",
+                                                    configurationService.getSecretValue(
+                                                            "OrdnanceSurveyAPIKey"))
                                             .method(SdkHttpMethod.GET)
                                             .build()
                                             .getUri())

--- a/lambdas/postcode-lookup/src/test/java/uk/gov/di/ipv/cri/address/api/service/PostcodeLookupServiceTest.java
+++ b/lambdas/postcode-lookup/src/test/java/uk/gov/di/ipv/cri/address/api/service/PostcodeLookupServiceTest.java
@@ -58,7 +58,8 @@ class PostcodeLookupServiceTest {
     void ioExceptionOrInterruptedThrowsProcessingException()
             throws IOException, InterruptedException {
         // Mock a valid url so service doesn't fall over validating URI
-        when(mockConfigurationService.getOsPostcodeAPIUrl()).thenReturn("http://localhost:8080/");
+        when(mockConfigurationService.getParameterValue("OrdnanceSurveyAPIURL"))
+                .thenReturn("http://localhost:8080/");
 
         // Simulate Http Client IO Failure
         when(httpClient.send(any(), any(HttpResponse.BodyHandlers.ofString().getClass())))
@@ -78,7 +79,8 @@ class PostcodeLookupServiceTest {
     @Test
     void invalidUrlThrowsProcessingException() throws PostcodeLookupProcessingException {
         // Simulate a failure of the URI builder
-        when(mockConfigurationService.getOsPostcodeAPIUrl()).thenReturn("invalidURL{}");
+        when(mockConfigurationService.getParameterValue("OrdnanceSurveyAPIURL"))
+                .thenReturn("invalidURL{}");
         assertThrows(
                 PostcodeLookupProcessingException.class,
                 () -> postcodeLookupService.lookupPostcode("ZZ1 1ZZ"));
@@ -87,7 +89,8 @@ class PostcodeLookupServiceTest {
     @Test
     void notFoundReturnsNoResults() throws IOException, InterruptedException {
         // Mock a valid url so service doesn't fall over validating URI
-        when(mockConfigurationService.getOsPostcodeAPIUrl()).thenReturn("http://localhost:8080/");
+        when(mockConfigurationService.getParameterValue("OrdnanceSurveyAPIURL"))
+                .thenReturn("http://localhost:8080/");
         // Simulate a 404 response
         when(mockResponse.statusCode()).thenReturn(HttpStatusCode.NOT_FOUND);
         when(httpClient.send(any(), any(HttpResponse.BodyHandlers.ofString().getClass())))
@@ -99,7 +102,8 @@ class PostcodeLookupServiceTest {
     @Test
     void badRequestReturnsEmptyButLogs() throws IOException, InterruptedException {
         // Mock a valid url so service doesn't fall over validating URI
-        when(mockConfigurationService.getOsPostcodeAPIUrl()).thenReturn("http://localhost:8080/");
+        when(mockConfigurationService.getParameterValue("OrdnanceSurveyAPIURL"))
+                .thenReturn("http://localhost:8080/");
         // Simulate a 400 bad request response
         when(mockResponse.statusCode()).thenReturn(HttpStatusCode.BAD_REQUEST);
         // Do NOT simulate a body
@@ -113,7 +117,8 @@ class PostcodeLookupServiceTest {
     @Test
     void badRequestReturnsEmptyButLogsWithDetails() throws IOException, InterruptedException {
         // Mock a valid url so service doesn't fall over validating URI
-        when(mockConfigurationService.getOsPostcodeAPIUrl()).thenReturn("http://localhost:8080/");
+        when(mockConfigurationService.getParameterValue("OrdnanceSurveyAPIURL"))
+                .thenReturn("http://localhost:8080/");
         // Simulate a 400 bad request response
         when(mockResponse.statusCode()).thenReturn(HttpStatusCode.BAD_REQUEST);
 
@@ -140,7 +145,8 @@ class PostcodeLookupServiceTest {
     @Test
     void non200ThrowsProcessingException() throws IOException, InterruptedException {
         // Mock a valid url so service doesn't fall over validating URI
-        when(mockConfigurationService.getOsPostcodeAPIUrl()).thenReturn("http://localhost:8080/");
+        when(mockConfigurationService.getParameterValue("OrdnanceSurveyAPIURL"))
+                .thenReturn("http://localhost:8080/");
         // Simulate a 500 response
         when(mockResponse.statusCode()).thenReturn(HttpStatusCode.INTERNAL_SERVER_ERROR);
         when(httpClient.send(any(), any(HttpResponse.BodyHandlers.ofString().getClass())))
@@ -154,7 +160,8 @@ class PostcodeLookupServiceTest {
     @Test
     void validPostcodeReturnsResults() throws IOException, InterruptedException {
         // Mock a valid url so service doesn't fall over validating URI
-        when(mockConfigurationService.getOsPostcodeAPIUrl()).thenReturn("http://localhost:8080/");
+        when(mockConfigurationService.getParameterValue("OrdnanceSurveyAPIURL"))
+                .thenReturn("http://localhost:8080/");
         // Simulate a 200 response
         when(mockResponse.statusCode()).thenReturn(HttpStatusCode.OK);
         when(mockResponse.body())

--- a/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/AddressService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/AddressService.java
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import uk.gov.di.ipv.cri.address.library.exception.AddressProcessingException;
 import uk.gov.di.ipv.cri.address.library.persistence.item.AddressItem;
 import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
@@ -18,31 +16,22 @@ import java.util.Objects;
 import java.util.UUID;
 
 public class AddressService {
-    private final ConfigurationService configurationService;
     private final DataStore<AddressItem> dataStore;
     private final ObjectMapper objectMapper;
     private ObjectReader addressReader;
 
     @ExcludeFromGeneratedCoverageReport
-    public AddressService() {
-        this.configurationService = new ConfigurationService();
-        this.dataStore =
+    public AddressService(ConfigurationService configurationService, ObjectMapper objectMapper) {
+        this(
                 new DataStore<>(
-                        configurationService.getAddressTableName(),
+                        configurationService.getParameterValue("AddressTableName"),
                         AddressItem.class,
-                        DataStore.getClient());
-        this.objectMapper =
-                new ObjectMapper()
-                        .registerModule(new Jdk8Module())
-                        .registerModule(new JavaTimeModule());
+                        DataStore.getClient()),
+                objectMapper);
     }
 
-    public AddressService(
-            DataStore<AddressItem> dataStore,
-            ConfigurationService configurationService,
-            ObjectMapper objectMapper) {
+    public AddressService(DataStore<AddressItem> dataStore, ObjectMapper objectMapper) {
         this.dataStore = dataStore;
-        this.configurationService = configurationService;
         this.objectMapper = objectMapper;
     }
 

--- a/lib/src/test/java/uk/gov/di/ipv/cri/address/library/service/AddressServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/address/library/service/AddressServiceTest.java
@@ -16,7 +16,6 @@ import uk.gov.di.ipv.cri.address.library.exception.AddressProcessingException;
 import uk.gov.di.ipv.cri.address.library.persistence.item.AddressItem;
 import uk.gov.di.ipv.cri.common.library.persistence.DataStore;
 import uk.gov.di.ipv.cri.common.library.persistence.item.CanonicalAddress;
-import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -33,14 +32,12 @@ class AddressServiceTest {
     private static final UUID SESSION_ID = UUID.randomUUID();
     @Mock private DataStore<AddressItem> mockDataStore;
     @Mock private ObjectMapper mockObjectMapper;
-    @Mock private ConfigurationService mockConfigurationService;
 
     private AddressService addressService;
 
     @BeforeEach
     void setup() {
-        this.addressService =
-                new AddressService(mockDataStore, mockConfigurationService, mockObjectMapper);
+        this.addressService = new AddressService(mockDataStore, mockObjectMapper);
     }
 
     @Test


### PR DESCRIPTION
### What changed

Updated various methods to not refer to the address specific ConfigurationService methods

### Why did it change

So the address specific ConfigurationService methods can be removed.
