### PR TITLE
[KBV-589] run address CRI inside VPC

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -43,6 +43,10 @@ Conditions:
           - "none"
 Globals:
   Function:
+    VpcConfig:
+      SecurityGroupIds:
+        - !ImportValue cri-vpc-LambdaSecurityGroup
+      SubnetIds: !Split [ ",", !ImportValue cri-vpc-PrivateSubnets ]
     PermissionsBoundary: !If
       - UsePermissionsBoundary
       - !Ref PermissionsBoundary


### PR DESCRIPTION
## Proposed changes

### What changed

The address CRI template has been updated to run the lambda inside the VPC as per Fraud and KBV

### Why did it change

This brings Address into line with Fraud and KBV deployments which simplifies the deployment process and enhances security

### Issue tracking

- [KBV-589](https://govukverify.atlassian.net/browse/KBV-589)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

None