### PR TITLE
KBV-570 VPC endpoint ids from stack export

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -163,7 +163,7 @@ Resources:
           ResourcePath: '/*'
           HttpMethod: '*'
           # Disable data trace in production to avoid logging customer sensitive information
-          DataTraceEnabled: true
+          DataTraceEnabled: !If [IsProdEnvironment, false, true]
           MetricsEnabled: true
           ThrottlingRateLimit: 5
           ThrottlingBurstLimit: 10
@@ -207,7 +207,7 @@ Resources:
           ResourcePath: '/*'
           HttpMethod: '*'
           # Disable data trace in production to avoid logging customer sensitive information
-          DataTraceEnabled: true
+          DataTraceEnabled: !If [IsProdEnvironment, false, true]
           MetricsEnabled: true
           ThrottlingRateLimit: 5
           ThrottlingBurstLimit: 10

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -66,6 +66,7 @@ Globals:
         AWS_STACK_NAME: !Sub ${AWS::StackName}
         POWERTOOLS_LOG_LEVEL: INFO
         SQS_AUDIT_EVENT_PREFIX: IPV_ADDRESS_CRI
+        POWERTOOLS_METRICS_NAMESPACE: di-ipv-cri-address-api
 Mappings:
 
   VPCEndpointIdMapping:
@@ -297,7 +298,6 @@ Resources:
       Handler: uk.gov.di.ipv.cri.common.api.handler.SessionHandler::handleRequest
       Environment:
         Variables:
-          POWERTOOLS_METRICS_NAMESPACE: di-ipv-cri-address-api
           POWERTOOLS_SERVICE_NAME: di-ipv-cri-address-api-session
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
       Policies:
@@ -345,7 +345,6 @@ Resources:
       Handler: uk.gov.di.ipv.cri.address.api.handler.PostcodeLookupHandler::handleRequest
       Environment:
         Variables:
-          POWERTOOLS_METRICS_NAMESPACE: di-ipv-cri-address-api
           POWERTOOLS_SERVICE_NAME: di-ipv-cri-address-api-postcode-lookup
       Policies:
         - AWSLambdaBasicExecutionRole
@@ -387,7 +386,6 @@ Resources:
       Handler: uk.gov.di.ipv.cri.address.api.handler.AddressHandler::handleRequest
       Environment:
         Variables:
-          POWERTOOLS_METRICS_NAMESPACE: di-ipv-cri-address-api
           POWERTOOLS_SERVICE_NAME: di-ipv-cri-address-api-address
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
       Policies:
@@ -432,7 +430,6 @@ Resources:
       Handler: uk.gov.di.ipv.cri.common.api.handler.AuthorizationHandler::handleRequest
       Environment:
         Variables:
-          POWERTOOLS_METRICS_NAMESPACE: di-ipv-cri-address-api
           POWERTOOLS_SERVICE_NAME: di-ipv-cri-address-api-authorization
       Policies:
         - AWSLambdaBasicExecutionRole
@@ -460,7 +457,6 @@ Resources:
       Handler: uk.gov.di.ipv.cri.common.api.handler.AccessTokenHandler::handleRequest
       Environment:
         Variables:
-          POWERTOOLS_METRICS_NAMESPACE: di-ipv-cri-address-api
           POWERTOOLS_SERVICE_NAME: di-ipv-cri-address-api-access-token
       Policies:
         - DynamoDBCrudPolicy:
@@ -487,7 +483,6 @@ Resources:
       CodeUri: ../../lambdas/issuecredential/build/distributions/issuecredential.zip
       Environment:
         Variables:
-          POWERTOOLS_METRICS_NAMESPACE: di-ipv-cri-address-api
           POWERTOOLS_SERVICE_NAME: di-ipv-cri-address-api-issuecredential
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
       Policies:
@@ -521,7 +516,6 @@ Resources:
       CodeUri: ../../common-lambdas/jwkset/build/distributions/jwkset.zip
       Environment:
         Variables:
-          POWERTOOLS_METRICS_NAMESPACE: di-ipv-cri-address-api
           POWERTOOLS_SERVICE_NAME: di-ipv-cri-address-api-jwkset
       Policies:
         - AWSLambdaBasicExecutionRole

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -71,32 +71,19 @@ Mappings:
 
   SessionTtlMapping:
     Environment:
-      dev: "172800" # 2 days
-      build: "172800" # 2 days
-      staging: "172800" # 2 days
-      integration: "172800" # 2 days
-      production: "172800" # 2 days
+      dev: 7200 # 2 hours
+      build: 7200 # 2 hours
+      staging: 7200 # 2 hours
+      integration: 7200 # 2 hours
+      production: 7200 # 2 hours
 
   MaxJwtTtlMapping:
     Environment:
-      dev: "9600" # 2 hrs
-      build: "2700" # 45 mins
-      staging: "2700"
-      integration: "2700"
-      production: "2700"
-
-  IPVCoreStubAuthenticationAlgMapping:
-    Environment:
-      dev: "ES256"
-      build: "ES256"
-      staging: "ES256"
-      integration: "ES256"
-
-  IPVCore1AuthenticationAlgMapping:
-    Environment:
-      staging: "ES256"
-      integration: "ES256"
-      production: "ES256"
+      dev: 7200 # 2 hours
+      build: 7200 # 2 hours
+      staging: 7200 # 2 hours
+      integration: 7200 # 2 hours
+      production: 7200 # 2 hours
 
   IPVCoreStubAudienceMapping:
     Environment:
@@ -681,22 +668,12 @@ Resources:
       Value: !FindInMap [ SessionTtlMapping, Environment, !Ref 'Environment' ]
       Description: default time to live for an address session item (seconds)
 
-  IPVCoreStubAuthenticationAlgParameter:
-    Condition: IsStubEnvironment
+  AuthenticationAlgParameter:
     Type: AWS::SSM::Parameter
     Properties:
       Name: !Sub "/${AWS::StackName}/clients/ipv-core-stub/jwtAuthentication/authenticationAlg"
       Type: String
-      Value: !FindInMap [IPVCoreStubAuthenticationAlgMapping, Environment, !Ref 'Environment']
-
-  IPVCore1AuthenticationAlgParameter:
-    Condition: IsProdLikeEnvironment
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub "/${AWS::StackName}/clients/ipv-core/jwtAuthentication/authenticationAlg"
-      Type: String
-      Value: !FindInMap [IPVCore1AuthenticationAlgMapping, Environment, !Ref 'Environment']
-
+      Value: ES256
 
   IPVCoreStubAudienceParameter:
     Condition: IsStubEnvironment

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -87,10 +87,10 @@ Mappings:
 
   IPVCoreStubAudienceMapping:
     Environment:
-      dev: "https://dev-di-ipv-cri-address-front.london.cloudapps.digital"
-      build: "https://build-di-ipv-cri-address-front.london.cloudapps.digital"
-      staging: "https://staging-di-ipv-cri-address-front.london.cloudapps.digital"
-      integration: "https://integration-di-ipv-cri-address-front.london.cloudapps.digital"
+      dev: "https://review-a.dev.account.gov.uk"
+      build: "https://review-a.build.account.gov.uk"
+      staging: "https://review-a.staging.account.gov.uk"
+      integration: "https://review-a.integration.account.gov.uk"
 
   IPVCore1AudienceMapping:
     Environment:

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -69,14 +69,6 @@ Globals:
         POWERTOOLS_METRICS_NAMESPACE: di-ipv-cri-address-api
 Mappings:
 
-  VPCEndpointIdMapping:
-    Environment:
-      dev: vpce-082cab7c78139eb54
-      build: vpce-0787187ab5693b050
-      staging: vpce-007b9da09e6aa5099
-      integration: vpce-0ab1f14412c691f58
-      production: vpce-0bc445fadec768f21
-
   SessionTtlMapping:
     Environment:
       dev: "172800" # 2 days
@@ -277,7 +269,10 @@ Resources:
                 - 'execute-api:/*'
               Condition:
                 StringNotEquals:
-                  'aws:SourceVpce': !FindInMap [ VPCEndpointIdMapping, Environment, !Ref 'Environment' ]
+                  aws:SourceVpce: !If
+                    - CreateDevResources
+                    - vpce-082cab7c78139eb54
+                    - !ImportValue cri-vpc-ApiGatewayVpcEndpointId
 
   PublicAddressApiAccessLogGroup:
     Type: AWS::Logs::LogGroup

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -27,6 +27,9 @@ Conditions:
   CreateDevResources: !Equals
     - !Ref Environment
     - dev
+  IsProdEnvironment: !Equals
+    - !Ref Environment
+    - production
   IsStubEnvironment: !Or
     - !Equals [ !Ref Environment, dev]
     - !Equals [ !Ref Environment, build ]


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

* [set env var POWERTOOLS_METRICS_NAMESPACE globally for lambdas](https://github.com/alphagov/di-ipv-cri-address-api/commit/9a37b26e68713033560ec24766eb1db5eac81522)
* [set source vpc endpoint id from a stack export, except for dev 😬](https://github.com/alphagov/di-ipv-cri-address-api/commit/5c884dc13cff3607ae5e01c25ea441dace9aff21)
* [set session and jwt ttl to 2 hrs, and set jwt sig alg to ES256 globally](https://github.com/alphagov/di-ipv-cri-address-api/commit/9c842e8377ee3c29c2d26b91f91700eabe089eb3)
* [normalise expected aud from core stub to use dns uris](https://github.com/alphagov/di-ipv-cri-address-api/commit/e77d94a831456c1a569e7092ecf8a8f51d709bb5)
* [set DataTraceEnabled to false for prod envs to not accidentally leak PII in API execution logs](https://github.com/alphagov/di-ipv-cri-address-api/commit/cb75c8269e782e8b2518d8ea7b02e9c06d4592f6)

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-570](https://govukverify.atlassian.net/browse/KBV-570)
