### PR TITLE
BAU: Clean up address private api

### DIFF
--- a/infrastructure/lambda/private-api.yaml
+++ b/infrastructure/lambda/private-api.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.1"
 info:
   version: "0.2"
-  title: "Address Credential Issuer API"
+  title: "Address Credential Issuer Private API"
 
 paths:
   /address:
@@ -174,141 +174,6 @@ paths:
           Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${AuthorizationFunction.Arn}/invocations"
         passthroughBehavior: "when_no_match"
 
-
-  /token:
-    post:
-      requestBody:
-        content:
-          application/x-www-form-urlencoded:
-            schema:
-              required:
-                - "grant_type"
-                - "code"
-                - "client_assertion_type"
-                - "client_assertion"
-                - "redirect_uri"
-              properties:
-                grant_type:
-                  type: "string"
-                  pattern: "authorization_code"
-                  example: "authorization_code"
-                code:
-                  type: "string"
-                  minLength: 1
-                client_assertion_type:
-                  type: "string"
-                  pattern: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
-                  example: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
-                client_assertion:
-                  type: "string"
-                  pattern: "[a-zA-Z0-9_=]+\\.[a-zA-Z0-9_=]+\\.[a-zA-Z0-9_\\-\\+\\/=]+"
-                  example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0dCIsImlhdCI6MTUxNjIzOTAyMn0.SbcN-ywpLObhMbbaMCtW1Un8LYhQzHsEth9LvTk4oQQ"
-                redirect_uri:
-                  type: "string"
-                  format: "uri"
-                  example: "https://di-ipv-core-stub.london.cloudapps.digital/callback"
-      responses:
-        "201":
-          description: "201 response"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/TokenResponse"
-        "400":
-          description: "400 response"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-        "500":
-          description: "500 response"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-
-      x-amazon-apigateway-request-validator: "Validate both"
-      x-amazon-apigateway-integration:
-        httpMethod: "POST"
-        uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${AccessTokenFunction.Arn}/invocations
-        responses:
-          default:
-            statusCode: "200"
-        passthroughBehavior: "when_no_match"
-        contentHandling: "CONVERT_TO_TEXT"
-        type: "aws_proxy"
-
-  /credential/issue:
-    summary: Resource for the Address API
-    description: >-
-      This API is expected to be called by the IPV core backend directly as the
-      final part of the OpenId/Oauth Flow
-    parameters:
-      - name: Authorization
-        in: header
-        required: true
-        description: 'A valid access_token (e.g.: authorization: Bearer access-token-value).'
-        schema:
-          type: string
-    post:
-      summary: GET request using a valid access token
-      responses:
-        '200':
-          description: 200 Ok
-          content:
-            application/jwt:
-              schema:
-                type: string
-                format: application/jwt
-                pattern: ^([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_\-\+\/=]+)$
-                example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
-        '400':
-          description: 400 Bad Response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-        '500':
-          description: 500 Internal server error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-
-      x-amazon-apigateway-request-validator: "Validate both"
-      x-amazon-apigateway-integration:
-        httpMethod: "POST"
-        uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IssueCredentialFunction.Arn}/invocations
-        responses:
-          default:
-            statusCode: "200"
-        passthroughBehavior: "when_no_match"
-        contentHandling: "CONVERT_TO_TEXT"
-        type: "aws_proxy"
-
-  /.well-known/jwks.json:
-    summary: Public Key JWKSet for the Address CRI
-    get:
-      responses:
-        '200':
-          description: 200 Ok
-          content:
-            application/jwk-set+json:
-              schema:
-                type: string
-      x-amazon-apigateway-integration:
-        httpMethod: "POST"
-        uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${JWKSetFunction.Arn}/invocations
-        responses:
-          default:
-            statusCode: "200"
-        passthroughBehavior: "when_no_match"
-        contentHandling: "CONVERT_TO_TEXT"
-        type: "aws_proxy"
-
 components:
   parameters:
     SessionHeader:
@@ -319,27 +184,6 @@ components:
       schema:
         type: string
   schemas:
-    TokenResponse:
-      title: AccessToken
-      required:
-        - "access_token"
-        - "expires_in"
-      type: "object"
-      properties:
-        access_token:
-          type: string
-          description: The Access Token for the given token request
-        token_type:
-          type: string
-          description: The Token Type issued
-          example: Bearer
-        expires_in:
-          type: string
-          description: The expiry time, in seconds
-          example: '3600'
-        refresh_token:
-          type: string
-          description: The refresh token is optional, not currently applicable
     Authorization:
       required:
         - "client_id"
@@ -451,4 +295,3 @@ x-amazon-apigateway-request-validators:
   Validate both:
     validateRequestBody: true
     validateRequestParameters: true
-


### PR DESCRIPTION
Remove protected public endpoints from Address private api, this is part of KBV-593
see also: https://github.com/alphagov/di-ipv-cri-address-api/pull/150

## Proposed changes

KBV-593 was reverted see https://github.com/alphagov/di-ipv-cri-address-api/pull/148

### What changed

Removed public api endpoints