### PR TITLE
[KBV-618] Remove JWKSetFunctionLogsSubscriptionFilter

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -624,14 +624,6 @@ Resources:
                 - kms:DescribeKey
               Resource: "*"
 
-  JWKSetFunctionLogsSubscriptionFilter:
-    Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevEnvironment
-    Properties:
-      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
-      FilterPattern: ""
-      LogGroupName: !Sub "/aws/lambda/${JWKSetFunction}"
-
   AddressTable:
     Type: "AWS::DynamoDB::Table"
     Properties:


### PR DESCRIPTION
## Proposed changes

### What changed

Removed JWKSetFunctionLogsSubscriptionFilter

### Why did it change

There is no log group for it so causes the deployment to fail

### Issue tracking

- [KBV-618](https://govukverify.atlassian.net/browse/KBV-618)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

