### PR TITLE
KBV-619 add provisioned concurrency to prod

### DIFF
--- a/infrastructure/lambda/private-api.yaml
+++ b/infrastructure/lambda/private-api.yaml
@@ -1,118 +1,49 @@
 openapi: "3.0.1"
 info:
   version: "0.2"
-  title: "Address Credential Issuer Private API"
+  title: "Address Credential Issuer Public API"
 
 paths:
-  /address:
-    put:
-      parameters:
-        - in: header
-          name: "session_id"
-          schema:
-            type: string
-            format: uuid
-          required: true
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/Address"
-        required: true
-      responses:
-        200:
-          description: "Address saved successfully"
-        201:
-          description: "Address saved and credential issued"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthorizationResponse"
-        400:
-          description: "Bad request"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-        401:
-          description: "Unauthorized"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-        500:
-          description: "Internal server error"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-      x-amazon-apigateway-request-validator: "Validate body" ## todo this validator doesn't exist
-      x-amazon-apigateway-integration:
-        httpMethod: "POST"
-        uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${AddressFunction.Arn}/invocations
-        responses:
-          default:
-            statusCode: "200"
-        passthroughBehavior: "when_no_match"
-        contentHandling: "CONVERT_TO_TEXT"
-        type: "aws_proxy"
 
-  /postcode-lookup/{postcode}:
-    get:
-      parameters:
-        - in: path
-          name: postcode
-          required: true
-          description: The postcode to look up
-          schema:
-            type: string
-        - in: header
-          name: "session_id"
-          schema:
-            type: string
-            format: uuid
-          required: true
-      responses:
-        "400":
-          description: "400 response"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-        "500":
-          description: "500 response"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-        "201":
-          description: "201 response"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PostcodeLookupResponse"
-      x-amazon-apigateway-request-validator: "Validate both"
-      x-amazon-apigateway-integration:
-        httpMethod: "POST"
-        uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${PostcodeLookupFunction.Arn}/invocations
-        responses:
-          default:
-            statusCode: "200"
-        passthroughBehavior: "when_no_match"
-        contentHandling: "CONVERT_TO_TEXT"
-        type: "aws_proxy"
-
-  /session:
+  /token:
     post:
       requestBody:
         content:
-          application/json:
+          application/x-www-form-urlencoded:
             schema:
-              $ref: "#/components/schemas/Authorization"
-        required: true
+              required:
+                - "grant_type"
+                - "code"
+                - "client_assertion_type"
+                - "client_assertion"
+                - "redirect_uri"
+              properties:
+                grant_type:
+                  type: "string"
+                  pattern: "authorization_code"
+                  example: "authorization_code"
+                code:
+                  type: "string"
+                  minLength: 1
+                client_assertion_type:
+                  type: "string"
+                  pattern: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+                  example: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+                client_assertion:
+                  type: "string"
+                  pattern: "[a-zA-Z0-9_=]+\\.[a-zA-Z0-9_=]+\\.[a-zA-Z0-9_\\-\\+\\/=]+"
+                  example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0dCIsImlhdCI6MTUxNjIzOTAyMn0.SbcN-ywpLObhMbbaMCtW1Un8LYhQzHsEth9LvTk4oQQ"
+                redirect_uri:
+                  type: "string"
+                  format: "uri"
+                  example: "https://di-ipv-core-stub.london.cloudapps.digital/callback"
       responses:
+        "201":
+          description: "201 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TokenResponse"
         "400":
           description: "400 response"
           content:
@@ -125,17 +56,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-        "201":
-          description: "201 response"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Session"
+
+      security:
+        - api_key: []
       x-amazon-apigateway-request-validator: "Validate both"
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SessionFunction.Arn}/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${AccessTokenFunction.Arn}:live/invocations
         responses:
           default:
             statusCode: "200"
@@ -143,153 +71,115 @@ paths:
         contentHandling: "CONVERT_TO_TEXT"
         type: "aws_proxy"
 
-  /authorization:
-    get:
-      parameters:
-        - $ref: "#/components/parameters/SessionHeader"
+  /credential/issue:
+    summary: Resource for the Address API
+    description: >-
+      This API is expected to be called by the IPV core backend directly as the
+      final part of the OpenId/Oauth Flow
+    parameters:
+      - name: Authorization
+        in: header
+        required: true
+        description: 'A valid access_token (e.g.: authorization: Bearer access-token-value).'
+        schema:
+          type: string
+    post:
+      summary: GET request using a valid access token
       responses:
-        "200":
-          description: "200 response"
+        '200':
+          description: 200 Ok
           content:
-            application/json:
+            application/jwt:
               schema:
-                $ref: "#/components/schemas/AuthorizationResponse"
-        "400":
-          description: "400 response"
+                type: string
+                format: application/jwt
+                pattern: ^([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_\-\+\/=]+)$
+                example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+        '400':
+          description: 400 Bad Response
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-        "500":
-          description: "500 response"
+        '500':
+          description: 500 Internal server error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+
+      security:
+        - api_key: []
       x-amazon-apigateway-request-validator: "Validate both"
       x-amazon-apigateway-integration:
-        type: "aws_proxy"
         httpMethod: "POST"
         uri:
-          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${AuthorizationFunction.Arn}/invocations"
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IssueCredentialFunction.Arn}:live/invocations
+        responses:
+          default:
+            statusCode: "200"
         passthroughBehavior: "when_no_match"
+        contentHandling: "CONVERT_TO_TEXT"
+        type: "aws_proxy"
+
+  /.well-known/jwks.json:
+    summary: Public Key JWKSet for the Address CRI
+    get:
+      responses:
+        '200':
+          description: 200 Ok
+          content:
+            application/jwk-set+json:
+              schema:
+                type: string
+      x-amazon-apigateway-integration:
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${JWKSetFunction.Arn}:live/invocations
+        responses:
+          default:
+            statusCode: "200"
+        passthroughBehavior: "when_no_match"
+        contentHandling: "CONVERT_TO_TEXT"
+        type: "aws_proxy"
 
 components:
-  parameters:
-    SessionHeader:
-      name: session-id
-      in: header
-      description: A UUID generated by the Session API to act as a primary key for the SessionTable in DynamoDB
-      required: true
-      schema:
-        type: string
   schemas:
-    Authorization:
+    TokenResponse:
+      title: AccessToken
       required:
-        - "client_id"
-        - "request"
+        - "access_token"
+        - "expires_in"
       type: "object"
       properties:
-        client_id:
-          type: "string"
-          minLength: 1
-          example: "ipv-core-stub"
-        request:
-          type: "string"
-    AuthorizationResponse:
-      required:
-        - "redirect_uri"
-        - "code"
-        - "state"
-      type: "object"
-      properties:
-        code:
-          type: "string"
-          example: "981bb74c-3b5e-462e-ba3a-abf868e5da68"
-        state:
-          type: "string"
-          example: "state"
-          minLength: 1
-        redirect_uri:
-          type: "string"
-          format: "uri"
-          example: "https://di-ipv-core-stub.london.cloudapps.digital/callback"
+        access_token:
+          type: string
+          description: The Access Token for the given token request
+        token_type:
+          type: string
+          description: The Token Type issued
+          example: Bearer
+        expires_in:
+          type: string
+          description: The expiry time, in seconds
+          example: '3600'
+        refresh_token:
+          type: string
+          description: The refresh token is optional, not currently applicable
+
     Error:
       title: "Error Schema"
       type: "object"
       properties:
         message:
           type: "string"
-    Session:
-      required:
-        - "session_id"
-      type: "object"
-      properties:
-        session_id:
-          type: "string"
-    PostcodeLookupResponse:
-      title: "Postcode Lookup Response"
-      type: "array"
-      items:
-        $ref: "#/components/schemas/CanonicalAddress"
-    Address:
-      title: "Address Update Request"
-      type: "array"
-      items:
-        $ref: "#/components/schemas/CanonicalAddress"
-    CanonicalAddress:
-      title: "Canonical Address"
-      type: "object"
-      properties:
-        uprn:
-          type: "number"
-          example: 1234567890
-          description: "Unique Property Reference Number"
-        organisationName:
-          type: "string"
-          example: "Some Organisation"
-        departmentName:
-          type: "string"
-          example: "Some Department"
-        subBuildingName:
-          type: "string"
-          example: "Some Sub Building"
-        buildingNumber:
-          type: "string"
-          example: "1"
-        dependentStreetName:
-          type: "string"
-          example: "Some Street"
-        doubleDependentAddressLocality:
-          type: "string"
-          example: "Some Town"
-        dependentAddressLocality:
-          type: "string"
-          example: "Some Area"
-        buildingName:
-          type: "string"
-          example: "Some Building"
-        streetName:
-          type: "string"
-          example: "Some Street"
-        addressLocality:
-          type: "string"
-          example: "Some Town"
-        postalCode:
-          type: "string"
-          example: "SW1A 1AA"
-        addressCountry:
-          type: "string"
-          example: "GB"
-          description: "ISO 2-Letter Country Code"
-        validFrom:
-          description: "Date in ISO 8601 format"
-          type: "string"
-          example: "2020-01-01"
-        validUntil:
-          description: "Date in ISO 8601 format"
-          type: "string"
-          example: "2020-01-01"
+
+
+  securitySchemes:
+    api_key:
+      type: "apiKey"
+      name: "x-api-key"
+      in: "header"
 
 x-amazon-apigateway-request-validators:
   Validate both:

--- a/infrastructure/lambda/public-api.yaml
+++ b/infrastructure/lambda/public-api.yaml
@@ -63,7 +63,7 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${AccessTokenFunction.Arn}/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${AccessTokenFunction.Arn}:live/invocations
         responses:
           default:
             statusCode: "200"
@@ -114,7 +114,7 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IssueCredentialFunction.Arn}/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IssueCredentialFunction.Arn}:live/invocations
         responses:
           default:
             statusCode: "200"
@@ -135,7 +135,7 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${JWKSetFunction.Arn}/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${JWKSetFunction.Arn}:live/invocations
         responses:
           default:
             statusCode: "200"

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -90,7 +90,7 @@ Mappings:
     dev:
       provisionedConcurrency: 0
     build:
-      provisionedConcurrency: 0
+      provisionedConcurrency: 1
     staging:
       provisionedConcurrency: 0
     integration:

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -49,6 +49,10 @@ Conditions:
       - Fn::Equals:
           - !Ref PermissionsBoundary
           - "none"
+  AddProvisionedConcurrency: !Not
+    - !Equals
+      - !FindInMap [ EnvironmentConfiguration, !Ref Environment, provisionedConcurrency ]
+      - 0
 Globals:
   Function:
     VpcConfig:
@@ -65,7 +69,6 @@ Globals:
       - !Ref CodeSigningConfigArn
     Timeout: 30 # seconds
     Runtime: java11
-    AutoPublishAlias: live
     Tracing: Active
     MemorySize: 512
     Environment:
@@ -75,11 +78,25 @@ Globals:
         POWERTOOLS_LOG_LEVEL: INFO
         SQS_AUDIT_EVENT_PREFIX: IPV_ADDRESS_CRI
         POWERTOOLS_METRICS_NAMESPACE: di-ipv-cri-address-api
-    ProvisionedConcurrencyConfig: !If
-      - IsProdEnvironment
-      - ProvisionedConcurrentExecutions: 1
+    AutoPublishAlias: live
+    ProvisionedConcurrencyConfig:
+      !If
+      - AddProvisionedConcurrency
+      - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref Environment, provisionedConcurrency ]
       - !Ref AWS::NoValue
 Mappings:
+
+  EnvironmentConfiguration:
+    dev:
+      provisionedConcurrency: 0
+    build:
+      provisionedConcurrency: 0
+    staging:
+      provisionedConcurrency: 0
+    integration:
+      provisionedConcurrency: 0
+    prod:
+      provisionedConcurrency: 1
 
   SessionTtlMapping:
     Environment:


### PR DESCRIPTION
## Proposed changes

### What changed

Conditional provisioned concurrency and alias added to template
Api configurations updated to use alias

### Why did it change

To enable provisioned concurrency in production

### Issue tracking

- [KBV-619](https://govukverify.atlassian.net/browse/KBV-619)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

This has been tested in the new address dev account with provisioned concurrency set to 1 and set to 0 to test both both production and non production deployments.