### PR TITLE
KBV-619 add provisioned concurrency

### DIFF
--- a/infrastructure/lambda/private-api.yaml
+++ b/infrastructure/lambda/private-api.yaml
@@ -50,7 +50,7 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${AddressFunction.Arn}/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${AddressFunction.Arn}:live/invocations
         responses:
           default:
             statusCode: "200"
@@ -96,7 +96,7 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${PostcodeLookupFunction.Arn}/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${PostcodeLookupFunction.Arn}:live/invocations
         responses:
           default:
             statusCode: "200"
@@ -135,7 +135,7 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SessionFunction.Arn}/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SessionFunction.Arn}:live/invocations
         responses:
           default:
             statusCode: "200"
@@ -171,7 +171,7 @@ paths:
         type: "aws_proxy"
         httpMethod: "POST"
         uri:
-          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${AuthorizationFunction.Arn}/invocations"
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${AuthorizationFunction.Arn}:live/invocations"
         passthroughBehavior: "when_no_match"
 
 components:

--- a/infrastructure/lambda/public-api.yaml
+++ b/infrastructure/lambda/public-api.yaml
@@ -63,7 +63,7 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${AccessTokenFunction.Arn}/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${AccessTokenFunction.Arn}:live/invocations
         responses:
           default:
             statusCode: "200"
@@ -114,7 +114,7 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IssueCredentialFunction.Arn}/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IssueCredentialFunction.Arn}:live/invocations
         responses:
           default:
             statusCode: "200"
@@ -135,7 +135,7 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${JWKSetFunction.Arn}/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${JWKSetFunction.Arn}:live/invocations
         responses:
           default:
             statusCode: "200"

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -49,6 +49,11 @@ Conditions:
       - Fn::Equals:
           - !Ref PermissionsBoundary
           - "none"
+  AddProvisionedConcurrency: !Not
+    - !Equals
+      - !FindInMap [ EnvironmentConfiguration, !Ref Environment, provisionedConcurrency ]
+      - 0
+
 Globals:
   Function:
     VpcConfig:
@@ -65,7 +70,6 @@ Globals:
       - !Ref CodeSigningConfigArn
     Timeout: 30 # seconds
     Runtime: java11
-    AutoPublishAlias: live
     Tracing: Active
     MemorySize: 512
     Environment:
@@ -75,11 +79,26 @@ Globals:
         POWERTOOLS_LOG_LEVEL: INFO
         SQS_AUDIT_EVENT_PREFIX: IPV_ADDRESS_CRI
         POWERTOOLS_METRICS_NAMESPACE: di-ipv-cri-address-api
-    ProvisionedConcurrencyConfig: !If
-      - IsProdEnvironment
-      - ProvisionedConcurrentExecutions: 1
+    AutoPublishAlias: live
+    ProvisionedConcurrencyConfig:
+      !If
+      - AddProvisionedConcurrency
+      - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref Environment, provisionedConcurrency ]
       - !Ref AWS::NoValue
+
 Mappings:
+
+  EnvironmentConfiguration:
+    dev:
+      provisionedConcurrency: 0
+    build:
+      provisionedConcurrency: 1
+    staging:
+      provisionedConcurrency: 0
+    integration:
+      provisionedConcurrency: 0
+    prod:
+      provisionedConcurrency: 1
 
   SessionTtlMapping:
     Environment:


### PR DESCRIPTION
## Proposed changes

### What changed

Conditional provisioned concurrency and alias added to template
Api configurations updated to use alias

### Why did it change

To enable provisioned concurrency in production

### Issue tracking

- [KBV-619](https://govukverify.atlassian.net/browse/KBV-619)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

This has been tested in the new address dev account with provisioned concurrency set to 1 and set to 0 to test both both production and non production deployments.