### PR TITLE
KBV-619 correct production mapping name

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -97,7 +97,7 @@ Mappings:
       provisionedConcurrency: 0
     integration:
       provisionedConcurrency: 0
-    prod:
+    production:
       provisionedConcurrency: 1
 
   SessionTtlMapping:


### PR DESCRIPTION

## Proposed changes

### What changed

Corrected mapping name for production

### Why did it change

Incorrect prod name used which prevented production deployment

### Issue tracking

- [KBV-619](https://govukverify.atlassian.net/browse/KBV-619)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

Fixes production deployment only