### PR TITLE
BAU Use ARM64 and change memory size per env

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -71,7 +71,9 @@ Globals:
     Timeout: 30 # seconds
     Runtime: java11
     Tracing: Active
-    MemorySize: 512
+    MemorySize: !FindInMap [ MemorySizeMapping, Environment, !Ref 'Environment' ]
+    Architectures:
+      - arm64
     Environment:
       Variables:
         JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1
@@ -87,6 +89,14 @@ Globals:
       - !Ref AWS::NoValue
 
 Mappings:
+
+  MemorySizeMapping:
+    Environment:
+      dev: 512
+      build: 1024
+      staging: 1024
+      integration: 1024
+      production: 2048
 
   EnvironmentConfiguration:
     dev:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Use [arm64 for better performance](https://aws.amazon.com/blogs/aws/aws-lambda-functions-powered-by-aws-graviton2-processor-run-your-functions-on-arm-and-get-up-to-34-better-price-performance/), and shift to more memory in higher environments.

KBV CRI has already  done it: https://github.com/alphagov/di-ipv-cri-kbv-api/pull/144/files

