### PR TITLE
KBV-778 remove test image push from GH workflows

### DIFF
--- a/.github/workflows/post-merge-package-for-build.yml
+++ b/.github/workflows/post-merge-package-for-build.yml
@@ -51,19 +51,6 @@ jobs:
       - name: SAM build
         run: sam build -t infrastructure/lambda/template.yaml
 
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-
-      - name: Build, tag, and push testing image to Amazon ECR
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
-          IMAGE_TAG: latest
-        run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG acceptance-tests
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-
       - name: SAM package
         run: |
           sam package -t infrastructure/lambda/template.yaml  \


### PR DESCRIPTION
## Proposed changes

### What changed

The test image included in the push to build has been removed.

### Why did it change

The acceptance test image is now being pushed from a different repository and workflow. The test image included in the push to build is no longer required and breaks the deployment so needs to be removed.

### Issue tracking

- [KBV-778](https://govukverify.atlassian.net/browse/KBV-778)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

None