### PR TITLE
KBV-771 Link validUntil in a PREVIOUS address to validFrom in a CURRENT address

### DIFF
--- a/lambdas/address/src/main/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandler.java
+++ b/lambdas/address/src/main/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandler.java
@@ -74,6 +74,9 @@ public class AddressHandler
             if (!addresses.isEmpty()) {
                 SessionItem session = sessionService.validateSessionId(sessionId);
 
+                // Links validUntil in a PREVIOUS address to validFrom in a CURRENT
+                addressService.setAddressValidity(addresses);
+
                 // Save our addresses to the address table
                 addressService.saveAddresses(UUID.fromString(sessionId), addresses);
 

--- a/lambdas/address/src/test/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandlerTest.java
+++ b/lambdas/address/src/test/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandlerTest.java
@@ -19,6 +19,7 @@ import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
 import uk.gov.di.ipv.cri.common.library.service.SessionService;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -87,6 +88,7 @@ class AddressHandlerTest {
 
         List<CanonicalAddress> canonicalAddresses = new ArrayList<>();
         CanonicalAddress canonicalAddress = new CanonicalAddress();
+        canonicalAddress.setValidFrom(LocalDate.of(2013, 8, 9));
         canonicalAddress.setUprn(Long.valueOf("12345"));
         canonicalAddresses.add(canonicalAddress);
 

--- a/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/AddressService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/AddressService.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.cri.address.library.exception.AddressProcessingException;
 import uk.gov.di.ipv.cri.address.library.persistence.item.AddressItem;
 import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
@@ -16,6 +18,18 @@ import java.util.Objects;
 import java.util.UUID;
 
 public class AddressService {
+    private static final Logger LOGGER = LogManager.getLogger();
+    private static final String ERROR_SINGLE_ADDRESS_NOT_CURRENT =
+            "setAddressValidity found a single address but is not a CURRENT address.";
+    private static final String ERROR_TOO_MANY_ADDRESSES =
+            "setAddressValidity given too many Addresses to process.";
+    private static final String ERROR_COULD_NOT_DETERMINE_CURRENT_ADDRESS =
+            "setAddressValidity found two addresses but could not determine which address is a CURRENT addressType.";
+    private static final String ERROR_ADDRESS_LINKING_NOT_NEEDED =
+            "setAddressValidity found PREVIOUS address but validUntil was already set - automatic date linking failed.";
+    private static final String ERROR_ADDRESS_DATE_IS_INVALID =
+            "setAddressValidity found address where validFrom and validUntil are Equal.";
+
     private final DataStore<AddressItem> dataStore;
     private final ObjectMapper objectMapper;
     private ObjectReader addressReader;
@@ -70,5 +84,95 @@ public class AddressService {
                             .without(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         }
         return this.addressReader;
+    }
+
+    // See https://govukverify.atlassian.net/wiki/spaces/PYI/pages/3178004485/Decision+Log
+    public void setAddressValidity(List<CanonicalAddress> addresses)
+            throws AddressProcessingException {
+
+        switch (addresses.size()) {
+            case 0:
+                LOGGER.warn("No Addresses to Process.");
+                return;
+            case 1:
+                if (isNotCurrentAddress(addresses.get(0))) {
+                    throw new AddressProcessingException(ERROR_SINGLE_ADDRESS_NOT_CURRENT);
+                }
+                LOGGER.info("Found a Single CURRENT Address.");
+                return;
+            case 2:
+                processAddresses(addresses);
+                return;
+            default:
+                // We cannot link multiple PREVIOUS address dates as they are null.
+                // Only the CURRENT address has date information.
+                throw new AddressProcessingException(ERROR_TOO_MANY_ADDRESSES);
+        }
+    }
+
+    private void processAddresses(List<CanonicalAddress> addresses)
+            throws AddressProcessingException {
+
+        CanonicalAddress currentAddress = null;
+        CanonicalAddress previousAddress = null;
+
+        CanonicalAddress address0 = addresses.get(0);
+        CanonicalAddress address1 = addresses.get(1);
+
+        // Check for a specific invalid case of the dates being equal
+        // This would fail against an addressType check in common-lib
+        if (isInvalidAddress(address0) || isInvalidAddress(address1)) {
+            throw new AddressProcessingException(ERROR_ADDRESS_DATE_IS_INVALID);
+        }
+
+        if (isCurrentAddress(address0) && isNotCurrentAddress(address1)) {
+            currentAddress = address0;
+            previousAddress = address1;
+        } else if (isCurrentAddress(address1) && isNotCurrentAddress(address0)) {
+            currentAddress = address1;
+            previousAddress = address0;
+        } else if (isCurrentAddress(address0) && isCurrentAddress(address1)) {
+
+            // This an edge case where there are two CURRENT address.
+            // Date linking is not performed.
+
+            LOGGER.info("Found two CURRENT Addresses.");
+
+            return;
+        } else {
+            throw new AddressProcessingException(ERROR_COULD_NOT_DETERMINE_CURRENT_ADDRESS);
+        }
+
+        // When AddressCRI Front is updated to set validUntil the linking needs to be removed
+        // else it would trample the dates already set
+        if (Objects.nonNull(previousAddress.getValidUntil())) {
+            // Not safe to automatically process dates in addresses
+            throw new AddressProcessingException(ERROR_ADDRESS_LINKING_NOT_NEEDED);
+        }
+
+        LOGGER.info("Found a CURRENT and PREVIOUS Address, linking validFrom with validUntil.");
+
+        // At this point the current address is known
+        previousAddress.setValidUntil(currentAddress.getValidFrom());
+    }
+
+    public boolean isCurrentAddress(CanonicalAddress canonicalAddress) {
+
+        // Due to PREVIOUS addresses coming from AddressFront without a date set for validUntil we
+        // cannot use common-lib to evaluate the type (as they would evaluate as CURRENT addresses)
+        // Instead we look for this as a CURRENT address pattern and treat all others as PREVIOUS
+
+        return Objects.nonNull(canonicalAddress.getValidFrom())
+                && Objects.isNull(canonicalAddress.getValidUntil());
+    }
+
+    public boolean isNotCurrentAddress(CanonicalAddress canonicalAddress) {
+        return !isCurrentAddress(canonicalAddress);
+    }
+
+    public boolean isInvalidAddress(CanonicalAddress canonicalAddress) {
+        return ((Objects.nonNull(canonicalAddress.getValidFrom())
+                        && Objects.nonNull(canonicalAddress.getValidUntil()))
+                && (canonicalAddress.getValidFrom().isEqual(canonicalAddress.getValidUntil())));
     }
 }

--- a/lib/src/main/resources/log4j2.xml
+++ b/lib/src/main/resources/log4j2.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+    <Appenders>
+        <Console name="JsonAppender" target="SYSTEM_OUT">
+            <JsonTemplateLayout eventTemplateUri="classpath:LambdaJsonLayout.json" />
+        </Console>
+        <Console name="ConsoleAppender" target="SYSTEM_OUT">
+            <PatternLayout pattern="%style{%date{DEFAULT}}{yellow}
+      %highlight{%-5level}{FATAL=bg_red, ERROR=red, WARN=yellow, INFO=green}
+      %message"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger name="JsonLogger" level="INFO" additivity="false">
+            <AppenderRef ref="JsonAppender"/>
+        </Logger>
+        <Root level="info">
+            <AppenderRef ref="${env:logAppender:-JsonAppender}"/>
+        </Root>
+    </Loggers>
+</Configuration>
+


### PR DESCRIPTION
## Proposed changes

### What changed

Added a utility method to addressService (setAddressValidity) to link validFrom in a CURRENT address with validUntil in a PREVIOUS address.

After this change AddressAPI will be limited to a max of two address, as validFrom is only set in CURRENT addresses.

ValidUntil will also appear in any PREVIOUS address in the VerifiableCredential, as the field is no longer null.

Additional validation of single address and address pairs.
Specific validation of address dates in addresses.

The setAddressValidity will only link a CURRENT and PREVIOUS address. If a PREVIOUS address with a non null validUntil is found it will not link the dates and throw an AddressProcessingException.

Internally setAddressValidity will use validFrom non-null and validUtil null as sole meaning of a CURRENT address and keeps this logic specific to the addressCRI. Commmon-lib is being changed so that null, null returns correctly as CURRENT address.

Added a Log4j configuration to address-lib to enable verbose logging in AddressService - setAddressValidity.

### Why did it change

AddressCRI currently only sets date information (validFrom) for CURRENT addresses with an additional address having no date information (null validFrom, null validUntil). This is not sufficient to perform a fraud check request with multiple addresses, as non null validUntil is needed to determine that this address is a PREVIOUS address - programatically via common-lib getAddressType().

Additional validation checks
- To ensure that if present that a single address can be evaluated as a CURRENT address.
- That if two address are present that one address can be evaluated as a CURRENT address, and then the validFrom date and validUntil dates are linked. Only if the address determined to be previous has null validUntil.
 
Specific validation of address dates
- For a single address this check is not needed as the dates would not match the isCurrentAddress() pattern.
- For two address the validation checks that the dates for validFrom and validUntil are not the same date, as otherwise later checks using common-lib (KBV-771) would fail this address pattern.

When AddressFront is updated to set dates for PREVIOUS address. To prevent silently corrupting data, setAddressValidity will throw an exception when it finds the PREVIOUS address already has a validUntil. The setAddressValidity method can then be removed.

Verbose logging is limited to setAddressValidity for its processing stages and includes a count of addresses encountered. This may help debugging any address related issues.

### Issue tracking

- [LIME-61](https://govukverify.atlassian.net/browse/LIME-61) formerly [KBV-771](https://govukverify.atlassian.net/browse/KBV-771) 
- [KBV-520](https://govukverify.atlassian.net/browse/KBV-520)
- [KBV-821](https://govukverify.atlassian.net/browse/KBV-821)