### PR TITLE
KBV-801 enable code signing in address dev

### DIFF
--- a/.github/workflows/post-merge-deploy-to-dev.yml
+++ b/.github/workflows/post-merge-deploy-to-dev.yml
@@ -49,6 +49,14 @@ jobs:
       - name: Gradle build
         run: ./gradlew build
 
+      - name: Generate code signing config
+        id: signing
+        uses: rusty-actions/sam-code-signing-config@39f63740a9f8622eb9b6755413a31a6013a62a86
+        with:
+          template: ./infrastructure/lambda/template.yaml
+          profile: ${{ secrets.DEV_SIGNING_PROFILE_NAME }}
+
+
       - name: SAM build
         run: sam build -t infrastructure/lambda/template.yaml
 

--- a/.github/workflows/pre-merge-integration-test.yml
+++ b/.github/workflows/pre-merge-integration-test.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: di-ipv-cri-dev
     timeout-minutes: 15
+    container:
+      image: ubuntu:latest
     env:
       AWS_REGION: eu-west-2
       ENVIRONMENT: dev
@@ -21,6 +23,17 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - name: Update/Install requirements
+        run: |
+          apt update --fix-missing -y && \
+          apt install -y software-properties-common 
+          apt upgrade -y
+          add-apt-repository ppa:git-core/ppa -y
+          add-apt-repository ppa:deadsnakes/ppa -y
+          apt update -y
+          apt install -y git
+          apt install -y python3.10
+          apt install -y python3.10-venv
       - name: Check out repo
         uses: actions/checkout@v2
         with:
@@ -43,12 +56,12 @@ jobs:
       - name: Gradle build
         run: ./gradlew build -x test -x spotlessCheck
 
-      - name: Generate code signing config
-        id: signing
-        uses: rusty-actions/sam-code-signing-config@39f63740a9f8622eb9b6755413a31a6013a62a86
-        with:
-          template: ./infrastructure/lambda/template.yaml
-          profile: ${{ secrets.SIGNING_PROFILE_NAME }}
+      - name: Update code signing config
+        run: |
+          START_LINE=$(grep -n CodeSigningConfigArn ./infrastructure/lambda/template.yaml | head -n 1 | sed 's/\([0-9]*\).*/\1/')
+          END_LINE=$(grep -n Environment ./infrastructure/lambda/template.yaml | head -n 1 | sed 's/\([0-9]*\).*/\1/')
+          sed -ie "${START_LINE},$((END_LINE-1))d" ./infrastructure/lambda/template.yaml
+          sed -ie '/CodeSigningConfig/d' ./infrastructure/lambda/template.yaml
 
       - name: SAM build
         run: sam build -t infrastructure/lambda/template.yaml

--- a/.github/workflows/pre-merge-integration-test.yml
+++ b/.github/workflows/pre-merge-integration-test.yml
@@ -43,6 +43,13 @@ jobs:
       - name: Gradle build
         run: ./gradlew build -x test -x spotlessCheck
 
+      - name: Generate code signing config
+        id: signing
+        uses: rusty-actions/sam-code-signing-config@39f63740a9f8622eb9b6755413a31a6013a62a86
+        with:
+          template: ./infrastructure/lambda/template.yaml
+          profile: ${{ secrets.SIGNING_PROFILE_NAME }}
+
       - name: SAM build
         run: sam build -t infrastructure/lambda/template.yaml
 

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -64,9 +64,7 @@ Globals:
       - UsePermissionsBoundary
       - !Ref PermissionsBoundary
       - !Ref AWS::NoValue
-    CodeSigningConfigArn: !If
-      - CreateDevResources
-      - !Ref AWS::NoValue
+    CodeSigningConfigArn:
       - !Ref CodeSigningConfigArn
     Timeout: 30 # seconds
     Runtime: java11
@@ -331,9 +329,7 @@ Resources:
                 - 'execute-api:/*'
               Condition:
                 StringNotEquals:
-                  aws:SourceVpce: !If
-                    - CreateDevResources
-                    - vpce-082cab7c78139eb54
+                  aws:SourceVpce:
                     - !ImportValue cri-vpc-ApiGatewayVpcEndpointId
 
   DevOnlyAddressApi:


### PR DESCRIPTION
## Proposed changes

### What changed

Turn on code signing in address dev

### Why did it change

The secure pipelines require code signing, the build fails when the deployment templates are updated unless manual adjustments to the deploy policies are subsequently made. Enabling code signing in the dev environments allows the use of updated secure pipeline templates without the need for manual manipulation.

### Issue tracking

- [KBV-801](https://govukverify.atlassian.net/browse/KBV-801)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

Unsigned deployments to the shared dev environment should still be possible.