### PR TITLE
OJ-822 rename log groups

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -472,7 +472,7 @@ Resources:
   SessionFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub "/aws/lambda/${SessionFunction}"
+      LogGroupName: !Sub "/aws/lambdalg/${SessionFunction}"
       RetentionInDays: 14
 
   SessionFunctionLogsSubscriptionFilter:
@@ -539,7 +539,7 @@ Resources:
   PostcodeLookupFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub "/aws/lambda/${PostcodeLookupFunction}"
+      LogGroupName: !Sub "/aws/lambdalg/${PostcodeLookupFunction}"
       RetentionInDays: 14
 
   PostcodeLookupFunctionLogsSubscriptionFilter:
@@ -586,7 +586,7 @@ Resources:
   AddressFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub "/aws/lambda/${AddressFunction}"
+      LogGroupName: !Sub "/aws/lambdalg/${AddressFunction}"
       RetentionInDays: 14
 
   AddressFunctionLogsSubscriptionFilter:
@@ -626,7 +626,7 @@ Resources:
   AuthorizationFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub "/aws/lambda/${AuthorizationFunction}"
+      LogGroupName: !Sub "/aws/lambdalg/${AuthorizationFunction}"
       RetentionInDays: 14
 
   AuthorizationFunctionLogsSubscriptionFilter:
@@ -666,7 +666,7 @@ Resources:
   AccessTokenFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub "/aws/lambda/${AccessTokenFunction}"
+      LogGroupName: !Sub "/aws/lambdalg/${AccessTokenFunction}"
       RetentionInDays: 14
 
   AccessTokenFunctionLogsSubscriptionFilter:
@@ -713,7 +713,7 @@ Resources:
   IssueCredentialFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub "/aws/lambda/${IssueCredentialFunction}"
+      LogGroupName: !Sub "/aws/lambdalg/${IssueCredentialFunction}"
       RetentionInDays: 14
 
 


### PR DESCRIPTION
## Proposed changes

### What changed

The log groups have been renamed

### Why did it change

These changes have been made to work around conflicts log group names with @clickopsed" log groups which is preventing the deployments downstream of build. 

### Issue tracking

- [OJ-822](https://govukverify.atlassian.net/browse/OJ-822)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

Log group names can be reverted if required in a subsequent PR after existing log groups have been deleted or otherhow renamed

PLEASE DO NOT MERGE!