### PR TITLE
Oj 928 add secrets detect to backend

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,7 @@
 <!-- List any related ADRs or RFCs -->
 <!-- Delete/copy as appropriate -->
 
-- [KBV-XXXX](https://govukverify.atlassian.net/browse/KBV-XXX)
+- [OJ-XXXX](https://govukverify.atlassian.net/browse/OJ-XXX)
 
 ## Checklists
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+# -   repo: https://github.com/pre-commit/pre-commit-hooks
+#     rev: v3.2.0
+#     hooks:
+#     -   id: trailing-whitespace
+#     -   id: end-of-file-fixer
+#     -   id: check-yaml
+#     -   id: check-added-large-files
+-   repo: https://github.com/Yelp/detect-secrets
+    rev: v1.3.0
+    hooks:
+    -   id: detect-secrets
+        args: ['--baseline', '.secrets.baseline']

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,186 @@
+{
+  "version": "1.3.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {
+    "infrastructure/lambda/public-api.yaml": [
+      {
+        "type": "JSON Web Token",
+        "filename": "infrastructure/lambda/public-api.yaml",
+        "hashed_secret": "01613fb1bb441c88d5e6773e2813ee026ad5b928",
+        "is_verified": false,
+        "line_number": 35
+      },
+      {
+        "type": "JSON Web Token",
+        "filename": "infrastructure/lambda/public-api.yaml",
+        "hashed_secret": "d6b66ddd9ea7dbe760114bfe9a97352a5e139134",
+        "is_verified": false,
+        "line_number": 100
+      }
+    ],
+    "infrastructure/lambda/template.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "infrastructure/lambda/template.yaml",
+        "hashed_secret": "407b058c0f67be53116117c4b021b5e95f9dca9e",
+        "is_verified": false,
+        "line_number": 188
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "infrastructure/lambda/template.yaml",
+        "hashed_secret": "486b0e17dde4271451ce7c815378fab9081085d1",
+        "is_verified": false,
+        "line_number": 199
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "infrastructure/lambda/template.yaml",
+        "hashed_secret": "81249afd017322b40765e849988f74ebc18e757c",
+        "is_verified": false,
+        "line_number": 200
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "infrastructure/lambda/template.yaml",
+        "hashed_secret": "54ec3197768e4b02c47ff91d4858f80b0c6fad30",
+        "is_verified": false,
+        "line_number": 201
+      }
+    ],
+    "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/service/fixtures/TestFixtures.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/service/fixtures/TestFixtures.java",
+        "hashed_secret": "dfd787252ff7385f31a57bddf4597e207b13fda7",
+        "is_verified": false,
+        "line_number": 12
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/service/fixtures/TestFixtures.java",
+        "hashed_secret": "095f47d22e20655016ead16e0264f994b0ef5323",
+        "is_verified": false,
+        "line_number": 14
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/service/fixtures/TestFixtures.java",
+        "hashed_secret": "3524aaa7f36b6a777ed767b1f2f3cc0512783810",
+        "is_verified": false,
+        "line_number": 16
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/service/fixtures/TestFixtures.java",
+        "hashed_secret": "76141ecdf327788c3f946f0d1a665cb945cff8ab",
+        "is_verified": false,
+        "line_number": 16
+      }
+    ]
+  },
+  "generated_at": "2022-09-12T08:21:12Z"
+}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # Address Collector Credential Issuer API
 
+## Hooks
+
+**important:** One you've cloned the repo, run `pre-commit install` to install the pre-commit hooks.
+If you have not installed `pre-commit` then please do so [here](https://pre-commit.com/).
+
 ## Check out submodules (First Time)
 > The first time you check out or clone the repository, you will need to run the following commands:
- 
+
 `git submodule update --init --recursive`
 
 ## Update submodules (Subsequent times)
@@ -11,7 +16,7 @@
 `git submodule update --recursive`
 
 ## Updating submodules to the latest "main" branch
-> You can also update the submodules to the latest "main" branch, but this is not done automatically 
+> You can also update the submodules to the latest "main" branch, but this is not done automatically
 > in case there have been changes made to the shared libraries you do not yet want to track
 
 cd into each submodule (folders are `/lib` and `/common-lambdas`) and run the following commands:
@@ -50,7 +55,7 @@ Before your **first** deploy, build a sam config toml file.
 > **Ensure you change the environment name**, when asked, to `dev` instead of `default`.
 > All other defaults can be accepted by leaving them blank
 
-The command to run is: 
+The command to run is:
 
 `gds aws  di-ipv-cri-dev -- sam deploy -t infrastructure/lambda/template.yaml --guided`
 
@@ -89,11 +94,11 @@ For Dev the following equivalent GitHub secrets:
 
 ## Publishing KMS Public keys
 
-The Address API uses an AWS KMS EC private key to sign verifiable credentials, 
+The Address API uses an AWS KMS EC private key to sign verifiable credentials,
 and an AWS KMS RSA private key to decrypt the Authorization JAR.
 
 The public keys need to be published so that clients:
-* can verify the signature of the verifiable credential, 
+* can verify the signature of the verifiable credential,
 * encrypt the Authorization JAR before sending to this CRI.
 
 The `JWKSetHandler` lambda function publishes these public keys as a JWKSet to `https://${AddressApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/.well-known/jwks.json`.


### PR DESCRIPTION
## Proposed changes

### What changed

Add secrets detect to the backend repos using precommit hook creator.  

### Why did it change

To help detect secrets from being leaked into the public domain. 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-928](https://govukverify.atlassian.net/browse/KBV-928)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks