### PR TITLE
BAU Check that at least one address is sent in the /PUT address method

### DIFF
--- a/infrastructure/lambda/private-api.yaml
+++ b/infrastructure/lambda/private-api.yaml
@@ -230,6 +230,7 @@ components:
     PostcodeLookupResponse:
       title: "Postcode Lookup Response"
       type: "array"
+      minItems: 1
       items:
         $ref: "#/components/schemas/CanonicalAddress"
     Address:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Check that at least one address is sent in the `/PUT address` method.

### What changed

Extra APIGW validation on address array

<!-- Describe the changes in detail - the "what"-->

### Why did it change

We were getting lambda errors trying to marshall an empty array or string to a `CanonicalAddress[]`. The APIGW should validate these cases, and return a 4xx to the client.

`minItems` is part of the [JSON validation schema](https://json-schema.org/draft/2020-12/json-schema-validation.html#name-minitems), and supported by OpenAPI 3.

<!-- Describe the reason these changes were made - the "why" -->
