### PR TITLE
OJ-931 - remove redundant include for common-lib

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,8 +1,5 @@
 rootProject.name = "di-ipv-cri-address-api"
 
-// Common libraries
-include "common-lib"
-
 // Common lambdas
 include "session", "accesstoken", "jwkset", "authorization"
 project(':session').projectDir = new File('./common-lambdas/session')


### PR DESCRIPTION
### What changed
- Removed `common-lib` from `settings.gradle`

### Why did it change
- The common-lib git submodule has been removed & the include was redundant

### Issue tracking
- [OJ-931](https://govukverify.atlassian.net/browse/OJ-931)
