### PR TITLE
OJ-972: Add pre-merge github-action to run API test

### DIFF
--- a/.github/workflows/pre-merge-integration-test.yml
+++ b/.github/workflows/pre-merge-integration-test.yml
@@ -64,7 +64,19 @@ jobs:
             --capabilities CAPABILITY_IAM
 
       - name: Run API integration tests
-        run: echo "🤞 now run integration tests..."
+        env:
+          IPV_CORE_STUB_URL: https://di-ipv-core-stub.london.cloudapps.digital
+          APIGW_API_KEY: ${{ secrets.API_KEY_CRI_DEV }}
+          IPV_CORE_STUB_BASIC_AUTH_USER: ${{ secrets.IPV_CORE_STUB_BASIC_AUTH_USER }}
+          IPV_CORE_STUB_BASIC_AUTH_PASSWORD: ${{ secrets.IPV_CORE_STUB_BASIC_AUTH_PASSWORD }}
+        run: |
+          STACK_NAME=${{ env.STACK_NAME_PREFIX }}-${{ steps.vars.outputs.sha_short }}
+          API_GATEWAY_ID_PRIVATE=$(aws cloudformation describe-stacks --stack-name $STACK_NAME | jq -r '.Stacks[].Outputs[] | select(.OutputKey == "PrivateAddressApiGatewayId").OutputValue')
+          API_GATEWAY_ID_PUBLIC=$(aws cloudformation describe-stacks --stack-name $STACK_NAME | jq -r '.Stacks[].Outputs[] | select(.OutputKey == "PublicAddressApiGatewayId").OutputValue')
+          export API_GATEWAY_ID_PRIVATE=$API_GATEWAY_ID_PRIVATE
+          export API_GATEWAY_ID_PUBLIC=$API_GATEWAY_ID_PUBLIC
+
+          gradle integration-tests:cucumber
 
       - name: Delete integration test stack
         if: always()


### PR DESCRIPTION
Co-authored-by: Aman Mohammed <aman.mohammed@digital.cabinet-office.gov.uk>

## Proposed changes

Introduce gitHub Actions to run API test 

### Why did it change

Happy Case Feature has been written for Address-Cri see: [OJ-966](https://github.com/alphagov/di-ipv-cri-address-api/pull/185)
- [OJ-972](https://govukverify.atlassian.net/browse/OJ-972)
