### PR TITLE
fix: use original resource name for old CSLS log subscription filter,…

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -73,6 +73,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -127,28 +131,28 @@
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "407b058c0f67be53116117c4b021b5e95f9dca9e",
         "is_verified": false,
-        "line_number": 188
+        "line_number": 198
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "486b0e17dde4271451ce7c815378fab9081085d1",
         "is_verified": false,
-        "line_number": 199
+        "line_number": 209
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "81249afd017322b40765e849988f74ebc18e757c",
         "is_verified": false,
-        "line_number": 200
+        "line_number": 210
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "54ec3197768e4b02c47ff91d4858f80b0c6fad30",
         "is_verified": false,
-        "line_number": 201
+        "line_number": 211
       }
     ],
     "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/service/fixtures/TestFixtures.java": [
@@ -182,5 +186,5 @@
       }
     ]
   },
-  "generated_at": "2022-09-12T08:21:12Z"
+  "generated_at": "2022-10-03T12:37:55Z"
 }

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -402,7 +402,7 @@ Resources:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-${PublicAddressApi}-public-AccessLogs
       RetentionInDays: 365
 
-  PublicAddressApiAccessLogGroupSubscriptionFilterOld:
+  PublicAddressApiAccessLogGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevEnvironment
     Properties:
@@ -410,7 +410,7 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref PublicAddressApiAccessLogGroup
 
-  PublicAddressApiAccessLogGroupSubscriptionFilter:
+  PublicAddressApiAccessLogGroupSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevEnvironment
     Properties:
@@ -432,7 +432,7 @@ Resources:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-${DevOnlyAddressApi}-private-AccessLogs
       RetentionInDays: 30
 
-  PrivateAddressApiAccessLogGroupSubscriptionFilterOld:
+  PrivateAddressApiAccessLogGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevEnvironment
     Properties:
@@ -440,7 +440,7 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref PrivateAddressApiAccessLogGroup
 
-  PrivateAddressApiAccessLogGroupSubscriptionFilter:
+  PrivateAddressApiAccessLogGroupSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevEnvironment
     Properties:
@@ -495,14 +495,14 @@ Resources:
               Resource:
                 - !ImportValue AuditEventQueueEncryptionKeyArn
 
-# Will need to enable and import at later date to overcome clean deployment issues
-#  SessionFunctionLogGroup:
-#    Type: AWS::Logs::LogGroup
-#    Properties:
-#      LogGroupName: !Sub "/aws/lambda/${SessionFunction}"
-#      RetentionInDays: 14
+  # Will need to enable and import at later date to overcome clean deployment issues
+  #  SessionFunctionLogGroup:
+  #    Type: AWS::Logs::LogGroup
+  #    Properties:
+  #      LogGroupName: !Sub "/aws/lambda/${SessionFunction}"
+  #      RetentionInDays: 14
 
-  SessionFunctionLogsSubscriptionFilterOld:
+  SessionFunctionLogsSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevEnvironment
     Properties:
@@ -510,7 +510,7 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Sub "/aws/lambda/${SessionFunction}"
 
-  SessionFunctionLogsSubscriptionFilter:
+  SessionFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevEnvironment
     Properties:
@@ -572,14 +572,14 @@ Resources:
               Resource:
                 - !ImportValue AuditEventQueueEncryptionKeyArn
 
-# Will need to enable and import at later date to overcome clean deployment issues
-#  PostcodeLookupFunctionLogGroup:
-#    Type: AWS::Logs::LogGroup
-#    Properties:
-#      LogGroupName: !Sub "/aws/lambda/${PostcodeLookupFunction}"
-#      RetentionInDays: 14
+  # Will need to enable and import at later date to overcome clean deployment issues
+  #  PostcodeLookupFunctionLogGroup:
+  #    Type: AWS::Logs::LogGroup
+  #    Properties:
+  #      LogGroupName: !Sub "/aws/lambda/${PostcodeLookupFunction}"
+  #      RetentionInDays: 14
 
-  PostcodeLookupFunctionLogsSubscriptionFilterOld:
+  PostcodeLookupFunctionLogsSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevEnvironment
     Properties:
@@ -587,7 +587,7 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Sub "/aws/lambda/${PostcodeLookupFunction}"
 
-  PostcodeLookupFunctionLogsSubscriptionFilter:
+  PostcodeLookupFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevEnvironment
     Properties:
@@ -628,14 +628,14 @@ Resources:
               Resource:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/clients/*"
 
-# Will need to enable and import at later date to overcome clean deployment issues
-#  AddressFunctionLogGroup:
-#    Type: AWS::Logs::LogGroup
-#    Properties:
-#      LogGroupName: !Sub "/aws/lambda/${AddressFunction}"
-#      RetentionInDays: 14
+  # Will need to enable and import at later date to overcome clean deployment issues
+  #  AddressFunctionLogGroup:
+  #    Type: AWS::Logs::LogGroup
+  #    Properties:
+  #      LogGroupName: !Sub "/aws/lambda/${AddressFunction}"
+  #      RetentionInDays: 14
 
-  AddressFunctionLogsSubscriptionFilterOld:
+  AddressFunctionLogsSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevEnvironment
     Properties:
@@ -643,7 +643,7 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Sub "/aws/lambda/${AddressFunction}"
 
-  AddressFunctionLogsSubscriptionFilter:
+  AddressFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevEnvironment
     Properties:
@@ -677,14 +677,14 @@ Resources:
               Resource:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/clients/*"
 
-# Will need to enable and import at later date to overcome clean deployment issues
-#  AuthorizationFunctionLogGroup:
-#    Type: AWS::Logs::LogGroup
-#    Properties:
-#      LogGroupName: !Sub "/aws/lambda/${AuthorizationFunction}"
-#      RetentionInDays: 14
+  # Will need to enable and import at later date to overcome clean deployment issues
+  #  AuthorizationFunctionLogGroup:
+  #    Type: AWS::Logs::LogGroup
+  #    Properties:
+  #      LogGroupName: !Sub "/aws/lambda/${AuthorizationFunction}"
+  #      RetentionInDays: 14
 
-  AuthorizationFunctionLogsSubscriptionFilterOld:
+  AuthorizationFunctionLogsSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevEnvironment
     Properties:
@@ -692,7 +692,7 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Sub "/aws/lambda/${AuthorizationFunction}"
 
-  AuthorizationFunctionLogsSubscriptionFilter:
+  AuthorizationFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevEnvironment
     Properties:
@@ -726,14 +726,14 @@ Resources:
               Resource:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/clients/*"
 
-# Will need to enable and import at later date to overcome clean deployment issues
-#  AccessTokenFunctionLogGroup:
-#    Type: AWS::Logs::LogGroup
-#    Properties:
-#      LogGroupName: !Sub "/aws/lambda/${AccessTokenFunction}"
-#      RetentionInDays: 14
+  # Will need to enable and import at later date to overcome clean deployment issues
+  #  AccessTokenFunctionLogGroup:
+  #    Type: AWS::Logs::LogGroup
+  #    Properties:
+  #      LogGroupName: !Sub "/aws/lambda/${AccessTokenFunction}"
+  #      RetentionInDays: 14
 
-  AccessTokenFunctionLogsSubscriptionFilterOld:
+  AccessTokenFunctionLogsSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevEnvironment
     Properties:
@@ -741,7 +741,7 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Sub "/aws/lambda/${AccessTokenFunction}"
 
-  AccessTokenFunctionLogsSubscriptionFilter:
+  AccessTokenFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevEnvironment
     Properties:
@@ -782,15 +782,15 @@ Resources:
             Resource:
               - !ImportValue AuditEventQueueEncryptionKeyArn
 
-# Will need to enable and import at later date to overcome clean deployment issues
-#  IssueCredentialFunctionLogGroup:
-#    Type: AWS::Logs::LogGroup
-#    Properties:
-#      LogGroupName: !Sub "/aws/lambda/${IssueCredentialFunction}"
-#      RetentionInDays: 14
+  # Will need to enable and import at later date to overcome clean deployment issues
+  #  IssueCredentialFunctionLogGroup:
+  #    Type: AWS::Logs::LogGroup
+  #    Properties:
+  #      LogGroupName: !Sub "/aws/lambda/${IssueCredentialFunction}"
+  #      RetentionInDays: 14
 
 
-  IssueCredentialFunctionLogsSubscriptionFilterOld:
+  IssueCredentialFunctionLogsSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevEnvironment
     Properties:
@@ -798,7 +798,7 @@ Resources:
       FilterPattern: ""
       LogGroupName:  !Sub "/aws/lambda/${IssueCredentialFunction}"
 
-  IssueCredentialFunctionLogsSubscriptionFilter:
+  IssueCredentialFunctionLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevEnvironment
     Properties:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

use original resource name for old CSLS log subscription filter, drop dev on new filter and change name. 
My theory is we keep the existing resource BAU, and add the new resource cleanly. 

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change

The existing resource failed to update in address build 👇 

````


CREATE_FAILED            AWS::Logs::Subscriptio   PostcodeLookupFunction   Resource handler
--
429 | nFilter                  LogsSubscriptionFilter   returned message:
430 | Old                      "Resource limit
431 | exceeded. (Service:
432 | CloudWatchLogs, Status
433 | Code: 400, Request ID:
434 | xxxx-xx-xx-xxxx
435 | 3-xxxxxxxx)"
436 | (RequestToken: xxx
438 | xxxxxx,
439 | HandlerErrorCode:
440 | ServiceLimitExceeded)


````

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-XXXX](https://govukverify.atlassian.net/browse/OJ-XXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks