### PR TITLE
OJ-958: removed the zip build process for lambdas

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -eu
-./gradlew
 sam validate -t infrastructure/lambda/template.yaml
 sam build -t infrastructure/lambda/template.yaml --config-env dev
-sam deploy -t infrastructure/lambda/template.yaml --config-env dev --config-file samconfig.toml --no-fail-on-empty-changeset
+sam deploy --config-file infrastructure/lambda/samconfig.toml \
+   --config-env dev \
+   --config-file samconfig.toml \
+   --no-fail-on-empty-changeset \
+   --parameter-overrides   CodeSigningEnabled=false \
+   AuditEventNamePrefix=/common-cri-parameters/AddressAuditEventNamePrefix \
+   CriIdentifier=/common-cri-parameters/AddressCriIdentifier \
+   CommonStackName=address-common-cri-api

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -363,7 +363,7 @@ Resources:
   PostcodeLookupFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: ../../lambdas/postcode-lookup/build/distributions/postcode-lookup.zip
+      CodeUri: ../../lambdas/postcode-lookup
       Handler: uk.gov.di.ipv.cri.address.api.handler.PostcodeLookupHandler::handleRequest
       Environment:
         Variables:
@@ -438,7 +438,7 @@ Resources:
   AddressFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: ../../lambdas/address/build/distributions/address.zip
+      CodeUri: ../../lambdas/address
       Handler: uk.gov.di.ipv.cri.address.api.handler.AddressHandler::handleRequest
       Environment:
         Variables:
@@ -492,7 +492,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: uk.gov.di.ipv.cri.address.api.handler.IssueCredentialHandler::handleRequest
-      CodeUri: ../../lambdas/issuecredential/build/distributions/issuecredential.zip
+      CodeUri: ../../lambdas/issuecredential
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-issuecredential"

--- a/lambdas/address/build.gradle
+++ b/lambdas/address/build.gradle
@@ -20,15 +20,6 @@ dependencies {
 	testRuntimeOnly configurations.test_runtime
 }
 
-task buildZip(type: Zip) {
-	from compileJava
-	from processResources
-	into('lib') {
-		from configurations.runtimeClasspath
-	}
-}
-
-build.finalizedBy(buildZip)
 test {
 	useJUnitPlatform()
 }

--- a/lambdas/issuecredential/build.gradle
+++ b/lambdas/issuecredential/build.gradle
@@ -20,16 +20,6 @@ dependencies {
 	testRuntimeOnly configurations.test_runtime
 }
 
-task buildZip(type: Zip) {
-	from compileJava
-	from processResources
-	into('lib') {
-		from configurations.runtimeClasspath
-	}
-}
-
-build.finalizedBy(buildZip)
-
 test {
 	useJUnitPlatform()
 	finalizedBy jacocoTestReport

--- a/lambdas/postcode-lookup/build.gradle
+++ b/lambdas/postcode-lookup/build.gradle
@@ -18,16 +18,6 @@ dependencies {
 	testRuntimeOnly configurations.test_runtime
 }
 
-task buildZip(type: Zip) {
-	from compileJava
-	from processResources
-	into('lib') {
-		from configurations.runtimeClasspath
-	}
-}
-
-build.finalizedBy(buildZip)
-
 test {
 	useJUnitPlatform()
 	finalizedBy jacocoTestReport


### PR DESCRIPTION
As per discussion we should not be using the logic to zip the `CodeUri` parameter for lambdas in the `template.yaml` while using AWS SAM 

## Proposed changes
`CodeUri: ../../lambdas/postcode-lookup`

### What changed
`CodeUri: ../../lambdas/postcode-lookup/build/distributions/postcode-lookup.zip` and associated `build.gradle` file in each Lambda.

The `deploy.sh` file has also been changed to stop using the `template.yaml` file during deployment, accommodate the common-lambdas and drop the`./gradlew` command.