### PR TITLE
Add github actions for tests and linting

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -8,6 +8,7 @@ on:
       - synchronize
 
 jobs:
+
   style-checks:
     runs-on: ubuntu-latest
     steps:
@@ -21,6 +22,26 @@ jobs:
           cache: 'gradle'
       - name: Run Spotless
         run: ./gradlew --no-daemon spotlessCheck
+
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-function:
+          - get-addresses
+    steps:
+      - name: Pull Repository
+        uses: actions/checkout@v3
+      - name: Set-up Node 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+      - name: NPM Install
+        working-directory: ./lambdas/${{ matrix.node-function }}
+        run: npm install
+      - name: run Lint
+        working-directory: ./lambdas/${{ matrix.node-function }}
+        run: npm run lint
 
   build:
     runs-on: ubuntu-latest
@@ -86,6 +107,26 @@ jobs:
           path: |
             */build/jacoco/
             */build/reports/
+
+  run-unit-tests-node:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-function:
+          - get-addresses
+    steps:
+      - name: Pull Repository
+        uses: actions/checkout@v3
+      - name: Set-up Node 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+      - name: NPM Install
+        working-directory: ./lambdas/${{ matrix.node-function }}
+        run: npm install
+      - name: run node tests
+        working-directory: ./lambdas/${{ matrix.node-function }}
+        run: npm run test
 
   run-sonar-analysis:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,14 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
-# -   repo: https://github.com/pre-commit/pre-commit-hooks
-#     rev: v3.2.0
-#     hooks:
-#     -   id: trailing-whitespace
-#     -   id: end-of-file-fixer
-#     -   id: check-yaml
-#     -   id: check-added-large-files
 -   repo: https://github.com/Yelp/detect-secrets
     rev: v1.3.0
     hooks:
     -   id: detect-secrets
         args: ['--baseline', '.secrets.baseline']
+-   repo: https://github.com/pre-commit/mirrors-eslint
+    rev: 'v8.24.0'  # Use the sha / tag you want to point at
+    hooks:
+    -   id: eslint
+        files: \.[jt]sx?$  # *.js, *.jsx, *.ts and *.tsx
+        types: [file]


### PR DESCRIPTION
## Proposed changes

### What changed

Added github actions to lint and run the tests of the nodelambda functions.

It would be cool if we got around to use precommit in our github actions to run all our checks.

### Why did it change

Runs linter and tests when we create a PR.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-958](https://govukverify.atlassian.net/browse/OJ-958)

