### PR TITLE
sum apigw errors across public and private gateways

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -758,8 +758,19 @@ Resources:
               Namespace: AWS/ApiGateway
               MetricName: 5XXError
               Dimensions:
-                - Name: Stage
-                  Value: !Ref Environment
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName}-PublicAddressApi"
+            Period: 300
+            Stat: Sum
+        - Id: m2
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: 5XXError
+              Dimensions:
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName}-PrivateAddressApi"
             Period: 300
             Stat: Sum
 
@@ -791,8 +802,19 @@ Resources:
               Namespace: AWS/ApiGateway
               MetricName: 4XXError
               Dimensions:
-                - Name: Stage
-                  Value: !Ref Environment
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName}-PublicAddressApi"
+            Period: 300
+            Stat: Sum
+        - Id: m2
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: 4XXError
+              Dimensions:
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName}-PrivateAddressApi"
             Period: 300
             Stat: Sum
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

For 5xx and 4x errors, use the sum of errors across the public and private API gateways.
Previously we used the sum of the API stage, and this didn't seem to work.

The sum expression `e1` is the only metric with `ReturnData: true` so this is the single metric that makes up the alarm.
