### PR TITLE
OJ-975 - Make VC JWT expiry more flexible

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ ext {
 		mockito                     : "4.3.1",
 		glassfish_version           : "3.0.3",
 		powertools_version          : "1.12.3",
-		cri_common_lib              : "1.1.5",
+		cri_common_lib              : "1.2.0"
 	]
 }
 

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -141,11 +141,20 @@ Mappings:
 
   MaxJwtTtlMapping:
     Environment:
-      dev: 7200 # 2 hours
-      build: 7200 # 2 hours
-      staging: 7200 # 2 hours
-      integration: 7200 # 2 hours
-      production: 7200 # 2 hours
+      dev: 2
+      build: 2
+      staging: 2
+      integration: 2
+      production: 2
+
+  # Permitted values: SECONDS,MINUTES,HOURS,DAYS,MONTHS,YEARS
+  JwtTtlUnitMapping:
+    Environment:
+      dev: HOURS
+      build: HOURS
+      staging: HOURS
+      integration: HOURS
+      production: HOURS
 
   OrdnanceSurveyAPIURLMapping:
     Environment:
@@ -486,6 +495,7 @@ Resources:
             Resource:
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/AddressTableName"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/MaxJwtTtl"
+              - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/JwtTtlUnit"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/verifiableCredentialKmsSigningKeyId"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTableName"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/verifiable-credential/issuer"
@@ -628,8 +638,16 @@ Resources:
     Properties:
       Name: !Sub "/${AWS::StackName}/MaxJwtTtl"
       Type: String
-      Value: !FindInMap [MaxJwtTtlMapping, Environment, !Ref 'Environment']
+      Value: !FindInMap [MaxJwtTtlMapping, Environment, !Ref Environment]
       Description: default time to live for an JWT in (seconds)
+
+  JwtTtlUnitParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/JwtTtlUnit"
+      Type: String
+      Value: !FindInMap [ JwtTtlUnitMapping, Environment, !Ref Environment ]
+      Description: The unit for the time-to-live for an JWT e.g. (MONTHS)
 
   OrdnanceSurveyAPIURLParameter:
     Type: AWS::SSM::Parameter

--- a/integration-tests/src/test/java/gov/uk/address/api/stepDefinitions/AddressApiHappyPath.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/stepDefinitions/AddressApiHappyPath.java
@@ -355,6 +355,15 @@ public class AddressApiHappyPath {
                 payload.get("result").get("addresses").get(0).get("postalCode").asText());
     }
 
+    @And("JWT lives for two hours")
+    public void jwt_lives_for_two_hours() throws ParseException, IOException {
+        SignedJWT decodedJWT = SignedJWT.parse(response.body());
+        var payload = objectMapper.readTree(decodedJWT.getPayload().toString());
+        assertNotNull(payload.get("nbf"));
+        assertNotNull(payload.get("exp"));
+        assertEquals(7200L, payload.get("exp").asLong() - payload.get("nbf").asLong());
+    }
+
     private void makeAssertions(SignedJWT decodedJWT) throws IOException {
         var header = decodedJWT.getHeader().toString();
         var payload = objectMapper.readTree(decodedJWT.getPayload().toString());

--- a/integration-tests/src/test/resources/features/AddressAPIHappyPath.feature
+++ b/integration-tests/src/test/resources/features/AddressAPIHappyPath.feature
@@ -26,6 +26,7 @@ Feature: Address API happy path test
     #Credential Issue
     When user sends a POST request to Credential Issue end point with a valid access token
     And a valid JWT is returned in the response
+    And JWT lives for two hours
 
     #Get_Addresses
     When user sends a GET request to Addresses end point

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/domain/VerifiableCredentialConstants.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/domain/VerifiableCredentialConstants.java
@@ -1,15 +1,10 @@
 package uk.gov.di.ipv.cri.address.api.domain;
 
 public class VerifiableCredentialConstants {
-    public static final String VC_CONTEXT = "@context";
     public static final String W3_BASE_CONTEXT = "https://www.w3.org/2018/credentials/v1";
     public static final String DI_CONTEXT =
             "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld";
-    public static final String VC_TYPE = "type";
-    public static final String VERIFIABLE_CREDENTIAL_TYPE = "VerifiableCredential";
     public static final String ADDRESS_CREDENTIAL_TYPE = "AddressCredential";
-    public static final String VC_CREDENTIAL_SUBJECT = "credentialSubject";
-    public static final String VC_CLAIM = "vc";
     public static final String VC_ADDRESS_KEY = "address";
 
     private VerifiableCredentialConstants() {}

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/service/VerifiableCredentialServiceTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/service/VerifiableCredentialServiceTest.java
@@ -1,7 +1,5 @@
 package uk.gov.di.ipv.cri.address.api.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -14,17 +12,21 @@ import com.nimbusds.jwt.SignedJWT;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.address.api.service.fixtures.TestFixtures;
 import uk.gov.di.ipv.cri.common.library.persistence.item.CanonicalAddress;
 import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.common.library.util.SignedJWTFactory;
+import uk.gov.di.ipv.cri.common.library.util.VerifiableCredentialClaimsSetBuilder;
 
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.text.ParseException;
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 
@@ -32,177 +34,127 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.cri.address.api.domain.VerifiableCredentialConstants.VC_ADDRESS_KEY;
-import static uk.gov.di.ipv.cri.address.api.domain.VerifiableCredentialConstants.VC_CLAIM;
-import static uk.gov.di.ipv.cri.address.api.domain.VerifiableCredentialConstants.VC_CREDENTIAL_SUBJECT;
+import static uk.gov.di.ipv.cri.address.api.domain.VerifiableCredentialConstants.ADDRESS_CREDENTIAL_TYPE;
+import static uk.gov.di.ipv.cri.address.api.domain.VerifiableCredentialConstants.DI_CONTEXT;
+import static uk.gov.di.ipv.cri.address.api.domain.VerifiableCredentialConstants.W3_BASE_CONTEXT;
 
 @ExtendWith(MockitoExtension.class)
 class VerifiableCredentialServiceTest implements TestFixtures {
-    public static final String SUBJECT = "subject";
-    public static final String UPRN = "72262801";
-    public static final String BUILDING_NUMBER = "8";
-    public static final String STREET_NAME = "GRANGE FIELDS WAY";
-
-    public static final String ADDRESS_LOCALITY = "LEEDS";
-    public static final String POSTAL_CODE = "LS10 4QL";
-    public static final String COUNTRY_CODE = "GB";
-    public static final LocalDate VALID_FROM = LocalDate.of(2010, 2, 26);
-    public static final LocalDate VALID_UNTIL = LocalDate.of(2021, 1, 16);
+    private static final JWTClaimsSet TEST_CLAIMS_SET =
+            new JWTClaimsSet.Builder().subject("test").issuer("test").build();
+    private static final long DEFAULT_JWT_TTL = 6L;
+    private static final String DEFAULT_JWT_TTL_UNIT = "MONTHS";
+    private static final String VC_ISSUER = "vc-issuer";
+    private static final String SUBJECT = "subject";
     private final ObjectMapper objectMapper =
             new ObjectMapper()
                     .registerModule(new Jdk8Module())
                     .registerModule(new JavaTimeModule());
     @Mock private ConfigurationService mockConfigurationService;
     @Mock private SignedJWTFactory mockSignedClaimSetJwt;
+    @Mock private VerifiableCredentialClaimsSetBuilder mockVcClaimSetBuilder;
+    @Captor private ArgumentCaptor<Map<String, Object>> mapArgumentCaptor;
 
     private VerifiableCredentialService verifiableCredentialService;
 
     @BeforeEach
     void setUp() {
-        when(mockConfigurationService.getVerifiableCredentialIssuer())
-                .thenReturn("https://address-cri.account.gov.uk.TBC");
         this.verifiableCredentialService =
                 new VerifiableCredentialService(
-                        mockSignedClaimSetJwt, mockConfigurationService, objectMapper);
+                        mockSignedClaimSetJwt,
+                        mockConfigurationService,
+                        objectMapper,
+                        mockVcClaimSetBuilder);
     }
 
     @Test
     void shouldReturnAVerifiedCredentialWhenGivenCanonicalAddresses() throws JOSEException {
-        when(mockConfigurationService.getVerifiableCredentialIssuer())
-                .thenReturn("address-cri-issue");
-        when(mockConfigurationService.getMaxJwtTtl()).thenReturn(342L);
+        initMockConfigurationService();
+        initMockVCClaimSetBuilder();
+        when(mockVcClaimSetBuilder.build()).thenReturn(TEST_CLAIMS_SET);
 
         var canonicalAddresses = List.of(mock(CanonicalAddress.class));
 
         verifiableCredentialService.generateSignedVerifiableCredentialJwt(
                 SUBJECT, canonicalAddresses);
 
-        verify(mockSignedClaimSetJwt).createSignedJwt(any());
+        verify(mockSignedClaimSetJwt).createSignedJwt(TEST_CLAIMS_SET);
     }
 
     @Test
     void shouldCreateValidSignedJWT()
-            throws InvalidKeySpecException, NoSuchAlgorithmException, JOSEException, ParseException,
-                    JsonProcessingException {
+            throws InvalidKeySpecException, NoSuchAlgorithmException, JOSEException,
+                    ParseException {
+        initMockConfigurationService();
+        initMockVCClaimSetBuilder();
+        when(mockVcClaimSetBuilder.build()).thenReturn(TEST_CLAIMS_SET);
 
         CanonicalAddress address = new CanonicalAddress();
-        address.setUprn(Long.valueOf(UPRN));
-        address.setBuildingNumber(BUILDING_NUMBER);
-        address.setStreetName(STREET_NAME);
-        address.setAddressLocality(ADDRESS_LOCALITY);
-        address.setPostalCode(POSTAL_CODE);
-        address.setAddressCountry(COUNTRY_CODE);
-        address.setValidFrom(VALID_FROM);
-        address.setValidUntil(VALID_UNTIL);
+        address.setUprn(72262801L);
+        address.setBuildingNumber("8");
+        address.setStreetName("GRANGE FIELDS WAY");
+        address.setAddressLocality("LEEDS");
+        address.setPostalCode("LS10 4QL");
+        address.setAddressCountry("GB");
+        address.setValidFrom(LocalDate.of(2010, 2, 26));
+        address.setValidUntil(LocalDate.of(2021, 1, 16));
         List<CanonicalAddress> canonicalAddresses = List.of(address);
 
         SignedJWTFactory signedJwtFactory = new SignedJWTFactory(new ECDSASigner(getPrivateKey()));
         verifiableCredentialService =
                 new VerifiableCredentialService(
-                        signedJwtFactory, mockConfigurationService, objectMapper);
+                        signedJwtFactory,
+                        mockConfigurationService,
+                        objectMapper,
+                        mockVcClaimSetBuilder);
 
         SignedJWT signedJWT =
                 verifiableCredentialService.generateSignedVerifiableCredentialJwt(
                         SUBJECT, canonicalAddresses);
-        JWTClaimsSet generatedClaims = signedJWT.getJWTClaimsSet();
         assertTrue(signedJWT.verify(new ECDSAVerifier(ECKey.parse(TestFixtures.EC_PUBLIC_JWK_1))));
 
-        JsonNode claimsSet = objectMapper.readTree(generatedClaims.toString());
-
-        assertEquals(5, claimsSet.size());
-
+        verify(mockVcClaimSetBuilder).build();
+        verify(mockVcClaimSetBuilder).subject(SUBJECT);
+        verify(mockVcClaimSetBuilder).verifiableCredentialType(ADDRESS_CREDENTIAL_TYPE);
+        verify(mockVcClaimSetBuilder)
+                .timeToLive(DEFAULT_JWT_TTL, ChronoUnit.valueOf(DEFAULT_JWT_TTL_UNIT));
+        verify(mockVcClaimSetBuilder)
+                .verifiableCredentialContext(new String[] {W3_BASE_CONTEXT, DI_CONTEXT});
+        verify(mockVcClaimSetBuilder).verifiableCredentialSubject(mapArgumentCaptor.capture());
+        Map<?, ?> vcSubjectClaims =
+                (Map<?, ?>) ((Object[]) mapArgumentCaptor.getValue().get("address"))[0];
         assertAll(
                 () -> {
+                    assertEquals(address.getUprn(), vcSubjectClaims.get("uprn"));
                     assertEquals(
-                            address.getUprn().toString(),
-                            claimsSet
-                                    .get(VC_CLAIM)
-                                    .get(VC_CREDENTIAL_SUBJECT)
-                                    .get(VC_ADDRESS_KEY)
-                                    .get(0)
-                                    .get("uprn")
-                                    .asText());
+                            address.getBuildingNumber(), vcSubjectClaims.get("buildingNumber"));
+                    assertEquals(address.getStreetName(), vcSubjectClaims.get("streetName"));
                     assertEquals(
-                            address.getBuildingNumber(),
-                            claimsSet
-                                    .get(VC_CLAIM)
-                                    .get(VC_CREDENTIAL_SUBJECT)
-                                    .get(VC_ADDRESS_KEY)
-                                    .get(0)
-                                    .get("buildingNumber")
-                                    .asText());
+                            address.getAddressLocality(), vcSubjectClaims.get("addressLocality"));
+                    assertEquals(address.getPostalCode(), vcSubjectClaims.get("postalCode"));
                     assertEquals(
-                            address.getStreetName(),
-                            claimsSet
-                                    .get(VC_CLAIM)
-                                    .get(VC_CREDENTIAL_SUBJECT)
-                                    .get(VC_ADDRESS_KEY)
-                                    .get(0)
-                                    .get("streetName")
-                                    .asText());
+                            address.getAddressCountry(), vcSubjectClaims.get("addressCountry"));
                     assertEquals(
-                            address.getAddressLocality(),
-                            claimsSet
-                                    .get(VC_CLAIM)
-                                    .get(VC_CREDENTIAL_SUBJECT)
-                                    .get(VC_ADDRESS_KEY)
-                                    .get(0)
-                                    .get("addressLocality")
-                                    .asText());
+                            address.getValidFrom().toString(), vcSubjectClaims.get("validFrom"));
                     assertEquals(
-                            address.getPostalCode(),
-                            claimsSet
-                                    .get(VC_CLAIM)
-                                    .get(VC_CREDENTIAL_SUBJECT)
-                                    .get(VC_ADDRESS_KEY)
-                                    .get(0)
-                                    .get("postalCode")
-                                    .asText());
-                    assertEquals(
-                            address.getAddressCountry(),
-                            claimsSet
-                                    .get(VC_CLAIM)
-                                    .get(VC_CREDENTIAL_SUBJECT)
-                                    .get(VC_ADDRESS_KEY)
-                                    .get(0)
-                                    .get("addressCountry")
-                                    .asText());
-                    assertEquals(
-                            "2010-02-26",
-                            claimsSet
-                                    .get(VC_CLAIM)
-                                    .get(VC_CREDENTIAL_SUBJECT)
-                                    .get(VC_ADDRESS_KEY)
-                                    .get(0)
-                                    .get("validFrom")
-                                    .asText());
-                    assertEquals(
-                            "2021-01-16",
-                            claimsSet
-                                    .get(VC_CLAIM)
-                                    .get(VC_CREDENTIAL_SUBJECT)
-                                    .get(VC_ADDRESS_KEY)
-                                    .get(0)
-                                    .get("validUntil")
-                                    .asText());
+                            address.getValidUntil().toString(), vcSubjectClaims.get("validUntil"));
                 });
-        ECDSAVerifier ecVerifier = new ECDSAVerifier(ECKey.parse(TestFixtures.EC_PUBLIC_JWK_1));
-        assertTrue(signedJWT.verify(ecVerifier));
     }
 
     @Test
     void shouldGetAuditEventContext() {
-        List<CanonicalAddress> testAddresses = List.of(new CanonicalAddress());
-        String vcIssuer = "vc-issuer";
-        when(mockConfigurationService.getVerifiableCredentialIssuer()).thenReturn(vcIssuer);
+        when(mockConfigurationService.getVerifiableCredentialIssuer()).thenReturn(VC_ISSUER);
 
         Map<String, Object> auditEventContext =
-                verifiableCredentialService.getAuditEventExtensions(testAddresses);
+                verifiableCredentialService.getAuditEventExtensions(
+                        List.of(new CanonicalAddress()));
 
-        assertEquals(vcIssuer, auditEventContext.get("iss"));
+        assertEquals(VC_ISSUER, auditEventContext.get("iss"));
         assertEquals(1, auditEventContext.get("addressesEntered"));
     }
 
@@ -213,5 +165,23 @@ class VerifiableCredentialServiceTest implements TestFixtures {
         Map<String, Object> auditEventContext =
                 verifiableCredentialService.getAuditEventExtensions(null);
         assertEquals(0, auditEventContext.get("addressesEntered"));
+    }
+
+    private void initMockVCClaimSetBuilder() {
+        when(mockVcClaimSetBuilder.subject(anyString())).thenReturn(mockVcClaimSetBuilder);
+        when(mockVcClaimSetBuilder.timeToLive(anyLong(), any(ChronoUnit.class)))
+                .thenReturn(mockVcClaimSetBuilder);
+        when(mockVcClaimSetBuilder.verifiableCredentialContext(any(String[].class)))
+                .thenReturn(mockVcClaimSetBuilder);
+        when(mockVcClaimSetBuilder.verifiableCredentialSubject(any()))
+                .thenReturn(mockVcClaimSetBuilder);
+        when(mockVcClaimSetBuilder.verifiableCredentialType(ADDRESS_CREDENTIAL_TYPE))
+                .thenReturn(mockVcClaimSetBuilder);
+    }
+
+    private void initMockConfigurationService() {
+        when(mockConfigurationService.getMaxJwtTtl()).thenReturn(DEFAULT_JWT_TTL);
+        when(mockConfigurationService.getParameterValue("JwtTtlUnit"))
+                .thenReturn(DEFAULT_JWT_TTL_UNIT);
     }
 }


### PR DESCRIPTION
### What changed
- Updated the VC JWT time-to-live assignment
- Updated to the latest version of cri-common-lib
- Removed redundant constants from the VerifiableCredentialConstants class
- Updated VerifiableCredentialService to use the new common VerifiableCredentialClaimsSetBuilder class

### Why did it change
- There is a future requirement to change the VC JWT time-to-live to 6 months. Now both the ttl and ttl unit can be specified e.g. 6 MONTHS
- There is unnecessary duplication of the logic to create the VC claims between the address, kbv & fraud CRIs

### Issue tracking
- [OJ-975](https://govukverify.atlassian.net/browse/OJ-975)
