### PR TITLE
OJ-1022 Updates for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,10 @@ updates:
     target-branch: main
     labels:
     - dependabot
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: main
+    labels:
+    - dependabot

--- a/.github/workflows/dependabot-pr-check-yml
+++ b/.github/workflows/dependabot-pr-check-yml
@@ -1,0 +1,14 @@
+### .github/workflows/dependabot-pr-check.yml
+### This workflow doesn't have access to secrets and has a read-only token
+### https://github.com/dependabot/dependabot-core/issues/3253
+### https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+name: Dependabot PR Check
+on:
+  pull_request
+
+jobs:
+  check-dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - run: echo "PR created by Dependabot"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
     - uses: pre-commit/action@v3.0.0
       with:
         extra_args: "detect-secrets --all-files"

--- a/.github/workflows/pre-merge-integration-test.yml
+++ b/.github/workflows/pre-merge-integration-test.yml
@@ -7,6 +7,11 @@ on:
       - ready_for_review
       - synchronize
 
+  workflow_run:
+    workflows: ["Dependabot PR Check"]
+    types:
+      - completed
+
 jobs:
   deploy:
     name: pre-merge-integration-tests
@@ -45,7 +50,7 @@ jobs:
 
       - name: Set short SHA
         id: vars
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: SAM deploy integration test stack
         run: |

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -114,7 +118,7 @@
         "filename": ".github/workflows/pre-merge-integration-test.yml",
         "hashed_secret": "4b0b79e641eb2908e8e42cb32013ce4d60348413",
         "is_verified": false,
-        "line_number": 20
+        "line_number": 25
       }
     ],
     "infrastructure/lambda/public-api.yaml": [
@@ -173,5 +177,5 @@
       }
     ]
   },
-  "generated_at": "2022-11-08T10:07:55Z"
+  "generated_at": "2022-11-10T10:53:07Z"
 }


### PR DESCRIPTION
## Proposed changes

### What changed

* Added dependabot PR check workflow that triggers the integration tests workflow
* Updated the dependabot configuration to include gradle and GHA dependencies 

### Why did it change

These changes are needed now that GitHub have tightened security that by default prevents secrets access from a fork which is effectively the process that dependabot uses.
The gradle and GHA changes allow improved visibility of updates and the option to merge PR's with updates.

(https://github.com/dependabot/dependabot-core/issues/3253)
(https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

### Issue tracking

- [OJ-1022](https://govukverify.atlassian.net/browse/OJ-1022)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks