### PR TITLE
OJ-1022 remove version from referenced workflow

### DIFF
--- a/.github/workflows/dependabot-pre-merge-integration-test.yml
+++ b/.github/workflows/dependabot-pre-merge-integration-test.yml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   deploy:
-    uses: ./.github/workflows/pre-merge-integration-test.yml@main
+    uses: ./.github/workflows/pre-merge-integration-test.yml


### PR DESCRIPTION
## Proposed changes

### What changed

Removed the @main version from the referenced workflow.

### Why did it change

Versions are not allowed on local workflow calls.

### Issue tracking

- [OJ-1022](https://govukverify.atlassian.net/browse/OJ-1022)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks