### PR TITLE
OJ-1110: add invalid postcode test

### DIFF
--- a/integration-tests/src/test/java/gov/uk/address/api/runners/RunCucumberTest.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/runners/RunCucumberTest.java
@@ -7,7 +7,7 @@ import org.junit.runner.RunWith;
 @RunWith(Cucumber.class)
 @CucumberOptions(
         plugin = {"json:target/cucumber.json", "html:target/default-html-reports"},
-        features = "src/test/resources",
+        features = "src/test/resources/features",
         glue = "gov/uk/address/api/stepdefinitions",
         dryRun = false)
 public class RunCucumberTest {}

--- a/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
@@ -1,5 +1,6 @@
 package gov.uk.address.api.stepdefinitions;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jwt.SignedJWT;
@@ -12,9 +13,11 @@ import uk.gov.di.ipv.cri.common.library.stepdefinitions.CriTestContext;
 
 import java.io.IOException;
 import java.text.ParseException;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AddressSteps {
 
@@ -99,5 +102,12 @@ public class AddressSteps {
                         .get(0)
                         .get("postalCode")
                         .asText());
+    }
+
+    @Then("user does not get any address")
+    public void user_does_not_get_any_address() throws JsonProcessingException {
+        var list = objectMapper.readValue(this.testContext.getResponse().body(), List.class);
+        assertTrue(list.isEmpty());
+        assertEquals(200, this.testContext.getResponse().statusCode());
     }
 }

--- a/integration-tests/src/test/resources/features/InvalidPostcodeTest.feature
+++ b/integration-tests/src/test/resources/features/InvalidPostcodeTest.feature
@@ -1,0 +1,17 @@
+Feature: Invalid postcode test
+
+  @invalid_postcode_test
+  Scenario Outline: Invalid postcode
+    Given user has the test-identity <testUserDataSheetRowNumber> in the form of a signed JWT string
+
+    #Session
+    When user sends a POST request to session end point
+    Then user gets a session-id
+
+    #Postcode Lookup
+    When the user performs a postcode lookup for post code "<testPostCode>"
+    Then user does not get any address
+
+    Examples:
+      | testUserDataSheetRowNumber | testPostCode |
+      | 197                        | XX12 12XX    |


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

We have added an invalid postcode API test

### Why did it change

We did not have an invalid postcode API test before
### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1110](https://govukverify.atlassian.net/browse/OJ-1110)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks