### PR TITLE
OJ-959 - send IPV_ADDRESS_CRI_END audit event

### DIFF
--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/handler/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/handler/IssueCredentialHandler.java
@@ -112,12 +112,18 @@ public class IssueCredentialHandler
             SignedJWT signedJWT =
                     verifiableCredentialService.generateSignedVerifiableCredentialJwt(
                             sessionItem.getSubject(), addressItem.getAddresses());
+
+            AuditEventContext auditEventContext =
+                    new AuditEventContext(input.getHeaders(), sessionItem);
             auditService.sendAuditEvent(
                     AuditEventType.VC_ISSUED,
-                    new AuditEventContext(input.getHeaders(), sessionItem),
+                    auditEventContext,
                     verifiableCredentialService.getAuditEventExtensions(
                             addressItem.getAddresses()));
+
             eventProbe.counterMetric(ADDRESS_CREDENTIAL_ISSUER);
+
+            auditService.sendAuditEvent(AuditEventType.END, auditEventContext);
 
             return ApiGatewayResponseGenerator.proxyJwtResponse(
                     HttpStatusCode.OK, signedJWT.serialize());

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/IssueCredentialHandlerTest.java
@@ -119,6 +119,9 @@ class IssueCredentialHandlerTest {
         AuditEventContext actualAuditEventContext = auditEventContextArgCaptor.getValue();
         assertEquals(event.getHeaders(), actualAuditEventContext.getRequestHeaders());
         assertEquals(sessionItem, actualAuditEventContext.getSessionItem());
+        verify(mockAuditService)
+                .sendAuditEvent(eq(AuditEventType.END), auditEventContextArgCaptor.capture());
+        assertEquals(sessionItem, auditEventContextArgCaptor.getValue().getSessionItem());
         assertEquals(
                 ContentType.APPLICATION_JWT.getType(), response.getHeaders().get("Content-Type"));
         assertEquals(HttpStatusCode.OK, response.getStatusCode());


### PR DESCRIPTION
### What changed
- Updated the IssueCredentialHandler class to send the END audit event

### Why did it change
- As requested by the txma team

### Issue tracking
- [OJ-959](https://govukverify.atlassian.net/browse/OJ-959)
