### PR TITLE
BAU: Parameterise deploy.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Any time you wish to deploy, run:
 
 Make sure you replace `STACKNAME` with your stack name that you want to deploy to.
 
+The CommonStackName and SecretPrefix are optional, but can be overridden by supplying
+
+additional arguments to `deploy.sh` i.e
+
+gds aws di-ipv-cri-dev -- ./deploy.sh STACKNAME YOUR-COMMON-STACKNAME YOUR-SECRET-PREFIX
+
 ## Deploy to AWS lambda
 
 Automated GitHub actions deployments to di-ipv-cri-build have been enabled for this repository.

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,6 +2,8 @@
 set -e
 
 stack_name="$1"
+common_stack_name="${2:-address-common-cri-api-local}"
+secret_prefix="${3:-address-cri-api}"
 
 if [ -z "$stack_name" ]
 then
@@ -23,5 +25,5 @@ sam deploy --stack-name "$stack_name" \
    Environment=dev \
    AuditEventNamePrefix=/common-cri-parameters/AddressAuditEventNamePrefix \
    CriIdentifier=/common-cri-parameters/AddressCriIdentifier \
-   CommonStackName=address-common-cri-api-local \
-   SecretPrefix=address-cri-api
+   CommonStackName="$common_stack_name" \
+   SecretPrefix="$secret_prefix"


### PR DESCRIPTION
This PR makes `deploy.sh` more configurable. If the need arises to work on an alternate common-stack. i.e one that has slightly different configuration to `address-common-cri-api-local` then you can specify yours as follows:

`gds aws di-ipv-cri-dev -- ./deploy.sh STACKNAME YOUR-COMMON-STACKNAME`

STACKNAME is your own stack address-cri stack that you have deployed to shared dev
YOUR-COMMON-STACKNAME is your own address common cri api-that your have deployed to shared, configured to your needs.



