### PR TITLE
OJ-1301 - Remove address information from audit log and exceptions

### DIFF
--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/handler/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/handler/IssueCredentialHandler.java
@@ -41,6 +41,7 @@ import uk.gov.di.ipv.cri.common.library.util.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 
 import java.time.Clock;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -118,8 +119,7 @@ public class IssueCredentialHandler
             auditService.sendAuditEvent(
                     AuditEventType.VC_ISSUED,
                     auditEventContext,
-                    verifiableCredentialService.getAuditEventExtensions(
-                            addressItem.getAddresses()));
+                    verifiableCredentialService.getAuditEventExtensions(List.of()));
 
             eventProbe.counterMetric(ADDRESS_CREDENTIAL_ISSUER);
 

--- a/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/AddressService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/AddressService.java
@@ -56,7 +56,7 @@ public class AddressService {
             addresses = getAddressReader().readValue(addressBody);
         } catch (JsonProcessingException e) {
             throw new AddressProcessingException(
-                    "could not parse addresses..." + e.getMessage(), e);
+                    "Could not parse addresses to a valid CanonicalAddress");
         }
 
         return addresses;

--- a/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/AddressService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/AddressService.java
@@ -56,7 +56,7 @@ public class AddressService {
             addresses = getAddressReader().readValue(addressBody);
         } catch (JsonProcessingException e) {
             throw new AddressProcessingException(
-                    "Could not parse addresses to a valid CanonicalAddress");
+                    "could not parse addresses..." + e.getMessage(), e);
         }
 
         return addresses;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

IssueCredentialHandler.java - Changed to audit an empty list instead of the users addresses, empty list so that no functional refactoring is required. This was done so we can't link this information to other logs to identify a user.

AddressService.java - To prevent Jackson propograting the JSON body in exception messages, the exception has been updated to a generic message.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
To ensure that personal information isn't logged or leaked via exceptions

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1301](https://govukverify.atlassian.net/browse/OJ-1301)

[OJ-1301]: https://govukverify.atlassian.net/browse/OJ-1301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ