### PR TITLE
OJ-1305: Use redaction deserializer in Address-cri

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ ext {
 		mockito                  : "4.3.1",
 		glassfish_version        : "3.0.3",
 		powertools_version       : "1.12.3",
-		cri_common_lib           : "1.4.5"
+		cri_common_lib           : "1.4.6"
 	]
 }
 

--- a/lambdas/address/src/main/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandler.java
+++ b/lambdas/address/src/main/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandler.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
@@ -25,6 +26,7 @@ import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.common.library.service.SessionService;
 import uk.gov.di.ipv.cri.common.library.util.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
+import uk.gov.di.ipv.cri.common.library.util.deserializers.PiiRedactingDeserializer;
 
 import java.util.List;
 import java.util.UUID;
@@ -47,7 +49,13 @@ public class AddressHandler
         ObjectMapper objectMapper =
                 new ObjectMapper()
                         .registerModule(new Jdk8Module())
-                        .registerModule(new JavaTimeModule());
+                        .registerModule(new JavaTimeModule())
+                        .registerModule(
+                                new SimpleModule()
+                                        .addDeserializer(
+                                                CanonicalAddress.class,
+                                                new PiiRedactingDeserializer<>(
+                                                        CanonicalAddress.class)));
         ConfigurationService configurationService = new ConfigurationService();
         this.sessionService = new SessionService();
         this.addressService = new AddressService(configurationService, objectMapper);

--- a/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/AddressService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/AddressService.java
@@ -55,8 +55,7 @@ public class AddressService {
         try {
             addresses = getAddressReader().readValue(addressBody);
         } catch (JsonProcessingException e) {
-            throw new AddressProcessingException(
-                    "Could not parse addresses to a valid CanonicalAddress");
+            throw new AddressProcessingException("could not parse addresses..." + e.getMessage());
         }
 
         return addresses;


### PR DESCRIPTION
## Proposed changes

Use the Redaction deserialiser in common-lib

### What changed

[A redaction deserializer was added to common-lib we can use this to strip possible PII](https://github.com/alphagov/di-ipv-cri-lib/pull/201)

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1305](https://govukverify.atlassian.net/browse/OJ-1305)


[OJ-1305]: https://govukverify.atlassian.net/browse/OJ-1305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ