### PR TITLE
OJ-1523: Ensure integration test works with AWS stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ Make sure you have deployed a stack on AWS and provide that `STACK_NAME` below w
 STACK_NAME=xxxx IPV_CORE_STUB_CRI_ID=address-cri-dev ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx  API_GATEWAY_ID_PUBLIC=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://di-ipv-core-stub.london.cloudapps.digital" APIGW_API_KEY=xxxx gradle integration-tests:cucumber
 ````
 
+Below runs by overriding the stub client to `https://cri.core.build.stubs.account.gov.uk` in AWS with stub a client_id ipv-core-stub-aws-stub using DEFAULT_CLIENT_ID env variable
+
+```
+ENVIRONMENT=dev STACK_NAME=xxxx IPV_CORE_STUB_CRI_ID=address-cri-dev  API_GATEWAY_ID_PRIVATE=xxxx API_GATEWAY_ID_PUBLIC=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://cri.core.build.stubs.account.gov.uk" DEFAULT_CLIENT_ID=ipv-core-stub-aws-build APIGW_API_KEY=xxxx gradle integration-tests:cucumber
+```
+
 ## Run a particular test
 ````
 STACK_NAME=xxxx IPV_CORE_STUB_CRI_ID=address-cri-dev ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx  API_GATEWAY_ID_PUBLIC=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://di-ipv-core-stub.london.cloudapps.digital" APIGW_API_KEY=xxxx gradle cucumber -P tags=@tag-name


### PR DESCRIPTION
## Proposed changes

Facilitate the ability to run the command https://github.com/alphagov/di-ipv-cri-kbv-api#run-integration-tests by changing IPV_CORE_STUB_URL to point to the new aws stub url i.e. https://cri.core.build.stubs.account.gov.uk

### What changed

In moving from PAAS to AWS, new client needed to be created, the current pre-merge test would need to be flexible enough to ensure the stub client Id can be overriding with the expected one.

### Why did it change

Work involving moving from PAAS to AWS

### Issue tracking

- [OJ-1523](https://govukverify.atlassian.net/browse/OJ-1523)

### Environment variables or secrets

New Env variable DEFAULT_CLIENT_ID 

### Other considerations

Updated [README](./blob/main/README.md) 

`ENVIRONMENT=xxxx STACK_NAME=xxxx IPV_CORE_STUB_CRI_ID=address-cri-dev API_GATEWAY_ID_PRIVATE=xxxx API_GATEWAY_ID_PUBLIC=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://cri.core.build.stubs.account.gov.uk" DEFAULT_CLIENT_ID=ipv-core-stub-aws-build APIGW_API_KEY=xxxx gradle integration-tests:cucumber`



[OJ-1523]: https://govukverify.atlassian.net/browse/OJ-1523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ