### PR TITLE
OJ-1533: Point Pre-merge-test to AWS stub

### DIFF
--- a/.github/workflows/pre-merge-integration-test.yml
+++ b/.github/workflows/pre-merge-integration-test.yml
@@ -76,7 +76,8 @@ jobs:
       - name: Run API integration tests
         env:
           ENVIRONMENT: dev
-          IPV_CORE_STUB_URL: https://di-ipv-core-stub.london.cloudapps.digital
+          DEFAULT_CLIENT_ID: ipv-core-stub-aws-build
+          IPV_CORE_STUB_URL: https://cri.core.build.stubs.account.gov.uk
           APIGW_API_KEY: ${{ secrets.API_KEY_CRI_DEV }}
           IPV_CORE_STUB_BASIC_AUTH_USER: ${{ secrets.IPV_CORE_STUB_BASIC_AUTH_USER }}
           IPV_CORE_STUB_BASIC_AUTH_PASSWORD: ${{ secrets.IPV_CORE_STUB_BASIC_AUTH_PASSWORD }}


### PR DESCRIPTION
## Proposed changes

Pre-merge-test to use AWS stub instead of PAAS stub

### What changed

Move away from PAAS to AWS hosting of stub

### Why did it change

PAAS would be decommission soon

### Issue tracking

- [OJ-1533](https://govukverify.atlassian.net/browse/OJ-1533)


### Environment variables or secrets

Use of DEFAULT_CLIENT_ID to specify stub client id
see: https://github.com/alphagov/di-ipv-cri-address-api/pull/599

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-1533]: https://govukverify.atlassian.net/browse/OJ-1533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ