### PR TITLE
OJ-1422: Add release_flag for vc-contains-unique-id

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ ext {
 		mockito                  : "4.3.1",
 		glassfish_version        : "3.0.3",
 		powertools_version       : "1.12.3",
-		cri_common_lib           : "1.4.6"
+		cri_common_lib           : "1.5.1"
 	]
 }
 

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -127,6 +127,14 @@ Mappings:
       integration: 1024
       production: 2048
 
+  VcContainsUniqueIdMapping:
+    Environment:
+      dev: "true"
+      build: "false"
+      staging: "false"
+      integration: "false"
+      production: "false"
+
   EnvironmentConfiguration:
     dev:
       provisionedConcurrency: 0
@@ -500,6 +508,7 @@ Resources:
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTableName"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/verifiable-credential/issuer"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/release-flags/vc-expiry-removed"
+              - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/release-flags/vc-contains-unique-id"
         - Statement:
             Effect: Allow
             Action:
@@ -667,6 +676,14 @@ Resources:
       Type: String
       Value: !Sub "{{resolve:ssm:/${CommonStackName}/PersonIdentityTableName}}"
       Description: Table name to retrieve addresses from store
+
+  ReleaseFlagsVcContainsUniqueIdParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/release-flags/vc-contains-unique-id"
+      Type: String
+      Value: !FindInMap [ VcContainsUniqueIdMapping, Environment, !Ref Environment ]
+      Description: Verifiable Credential Contains UniqueId Mapping
 
   PostcodeLookupFunctionPermission:
     Type: AWS::Lambda::Permission


### PR DESCRIPTION
## Proposed changes

Use release-flag for `vc-contains-unique-id`  for address-cri implemented by https://github.com/alphagov/di-ipv-cri-lib/pull/244

### What changed

Added release_flag for vc-contains-unique-id setting it to true In Dev

### Why did it change

see: https://github.com/alphagov/digital-identity-architecture/blob/main/adr/0079-unique-identifier-for-verifiable-credential.md#option-6---preferred-optionIn order to be able to distinguish one Verifiable Credential (VC) from another VC it will be necessary for VCs to be able to be uniquely identifiable

### Issue tracking


- [OJ-1422](https://govukverify.atlassian.net/browse/OJ-1422)


[OJ-1422]: https://govukverify.atlassian.net/browse/OJ-1422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ