### PR TITLE
OJ-1422: VC Contain Unique Id enabled up to staging

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -130,8 +130,8 @@ Mappings:
   VcContainsUniqueIdMapping:
     Environment:
       dev: "true"
-      build: "false"
-      staging: "false"
+      build: "true"
+      staging: "true"
       integration: "false"
       production: "false"
 


### PR DESCRIPTION
## Proposed changes

VC Contain Unique Id enabled up to staging 

### What changed

Included a unique identifier within the jti (JSON Web Token ID) claim representing a VC

### Why did it change

Added release_flag for `vc-contains-unique-id` this can be enabled by setting the environment flag to true in the template file. Below all env(s) up to staging have been enabled

```
  VcContainsUniqueIdMapping:
    Environment:
      dev: "true"
      build: "true"
      staging: "true"
      integration: "false"
      production: "false"
``` 

### Issue tracking
- [jti in context of a VC](https://github.com/alphagov/digital-identity-architecture/blob/7c90be0db85a3a3093c766d845d5f278a3d86e16/rfc/0045-claimed-identity-cri.md?plain=1#L217)
- [ADR 0079 Unique identifiers for verifiable credentials](https://github.com/alphagov/digital-identity-architecture/blob/7c90be0db85a3a3093c766d845d5f278a3d86e16/adr/0079-unique-identifier-for-verifiable-credential.md#option-6---preferred-option)

- [OJ-1422](https://govukverify.atlassian.net/browse/OJ-1422)

### Other considerations:
This PR is dependent on version 1.5.2 of the below
- see https://github.com/alphagov/di-ipv-cri-lib/pull/244

[OJ-1422]: https://govukverify.atlassian.net/browse/OJ-1422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ