### PR TITLE
OJ-1597: Added the RESPONSE_RECEIVED audit event

### DIFF
--- a/lambdas/postcode-lookup/src/main/java/uk/gov/di/ipv/cri/address/api/handler/PostcodeLookupHandler.java
+++ b/lambdas/postcode-lookup/src/main/java/uk/gov/di/ipv/cri/address/api/handler/PostcodeLookupHandler.java
@@ -73,9 +73,13 @@ public class PostcodeLookupHandler
         try {
             SessionItem sessionItem = sessionService.validateSessionId(sessionId);
             eventProbe.log(Level.INFO, "found session");
-            List<CanonicalAddress> results = postcodeLookupService.lookupPostcode(postcode);
             auditService.sendAuditEvent(
                     AuditEventType.REQUEST_SENT,
+                    postcodeLookupService.getAuditEventContext(
+                            postcode, input.getHeaders(), sessionItem));
+            List<CanonicalAddress> results = postcodeLookupService.lookupPostcode(postcode);
+            auditService.sendAuditEvent(
+                    AuditEventType.RESPONSE_RECEIVED,
                     postcodeLookupService.getAuditEventContext(
                             postcode, input.getHeaders(), sessionItem));
             eventProbe.counterMetric(LAMBDA_NAME);

--- a/lambdas/postcode-lookup/src/test/java/uk/gov/di/ipv/cri/address/api/handler/PostcodeLookupHanderTest.java
+++ b/lambdas/postcode-lookup/src/test/java/uk/gov/di/ipv/cri/address/api/handler/PostcodeLookupHanderTest.java
@@ -37,10 +37,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNotNull;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.willThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static uk.gov.di.ipv.cri.address.api.handler.PostcodeLookupHandler.LAMBDA_NAME;
 
 @ExtendWith(MockitoExtension.class)
@@ -150,10 +147,12 @@ class PostcodeLookupHanderTest {
                 postcodeLookupHandler.handleRequest(apiGatewayProxyRequestEvent, null);
         assertEquals(200, responseEvent.getStatusCode());
         verify(sessionService).validateSessionId(sessionId);
-        verify(postcodeLookupService)
+        verify(postcodeLookupService, times(2))
                 .getAuditEventContext(testPostcode, requestHeaders, sessionItem);
         verify(postcodeLookupService).lookupPostcode(testPostcode);
         verify(auditService).sendAuditEvent(AuditEventType.REQUEST_SENT, testAuditEventContext);
+        verify(auditService)
+                .sendAuditEvent(AuditEventType.RESPONSE_RECEIVED, testAuditEventContext);
         verify(eventProbe).counterMetric(LAMBDA_NAME);
         verifyNoMoreInteractions(eventProbe);
     }

--- a/lambdas/postcode-lookup/src/test/java/uk/gov/di/ipv/cri/address/api/handler/PostcodeLookupHanderTest.java
+++ b/lambdas/postcode-lookup/src/test/java/uk/gov/di/ipv/cri/address/api/handler/PostcodeLookupHanderTest.java
@@ -37,7 +37,11 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNotNull;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.willThrow;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.cri.address.api.handler.PostcodeLookupHandler.LAMBDA_NAME;
 
 @ExtendWith(MockitoExtension.class)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

`PostcodeLookupService.java` has been changed so that `RESPONSE_RECEIVED` is sent once we get a response from the post code lookup API. Moved `REQUEST_SENT` to happen before the function call so that it's more clear to when the call happened vs when the response was received. 

### Why did it change

The RESPONSE_RECEIVED audit event was missing. 

### Issue tracking

- [OJ-1597](https://govukverify.atlassian.net/browse/OJ-1597)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed


[OJ-1597]: https://govukverify.atlassian.net/browse/OJ-1597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ