### PR TITLE
Oj 1776/default address country

### DIFF
--- a/lambdas/address/src/main/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandler.java
+++ b/lambdas/address/src/main/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandler.java
@@ -88,6 +88,9 @@ public class AddressHandler
                 // Links validUntil in a PREVIOUS address to validFrom in a CURRENT
                 addressService.setAddressValidity(addresses);
 
+                // Sets missing addressCountry to be GB
+                addressService.setAddressCountryIfMissing(addresses);
+
                 // Save our addresses to the address table
                 addressService.saveAddresses(UUID.fromString(sessionId), addresses);
 

--- a/lambdas/address/src/test/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandlerTest.java
+++ b/lambdas/address/src/test/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandlerTest.java
@@ -107,6 +107,7 @@ class AddressHandlerTest {
 
         verify(mockSessionService).createAuthorizationCode(sessionItem);
         verify(mockAddressService).setAddressValidity(canonicalAddresses);
+        verify(mockAddressService).setAddressCountryIfMissing(canonicalAddresses);
         verify(eventProbe).log(Level.INFO, "found session");
         verify(eventProbe).counterMetric("address");
         verifyNoMoreInteractions(eventProbe);

--- a/lambdas/address/src/test/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandlerTest.java
+++ b/lambdas/address/src/test/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandlerTest.java
@@ -106,6 +106,7 @@ class AddressHandlerTest {
         assertEquals(HttpStatusCode.NO_CONTENT, responseEvent.getStatusCode());
 
         verify(mockSessionService).createAuthorizationCode(sessionItem);
+        verify(mockAddressService).setAddressValidity(canonicalAddresses);
         verify(eventProbe).log(Level.INFO, "found session");
         verify(eventProbe).counterMetric("address");
         verifyNoMoreInteractions(eventProbe);

--- a/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/AddressService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/AddressService.java
@@ -85,6 +85,13 @@ public class AddressService {
         return this.addressReader;
     }
 
+    public void setAddressCountryIfMissing(List<CanonicalAddress> addresses) {
+        addresses.stream()
+                .filter(Objects::nonNull)
+                .filter(address -> Objects.isNull(address.getAddressCountry()))
+                .forEach(address -> address.setAddressCountry("GB"));
+    }
+
     // See https://govukverify.atlassian.net/wiki/spaces/PYI/pages/3178004485/Decision+Log
     public void setAddressValidity(List<CanonicalAddress> addresses)
             throws AddressProcessingException {

--- a/lib/src/test/java/uk/gov/di/ipv/cri/address/library/service/AddressServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/address/library/service/AddressServiceTest.java
@@ -22,8 +22,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -185,6 +184,36 @@ class AddressServiceTest {
                 addressItemArgumentCaptor.getValue().getAddresses(), equalTo(addresses));
         MatcherAssert.assertThat(
                 addressItemArgumentCaptor.getValue().getSessionId(), equalTo(SESSION_ID));
+    }
+
+    @Test
+    void shouldSetAddressCountryIfNotProvided() {
+        List<CanonicalAddress> addresses = new ArrayList<>();
+        CanonicalAddress address1 = new CanonicalAddress();
+        address1.setPostalCode("LS10 4QL");
+        address1.setAddressCountry("GB");
+        address1.setValidFrom(LocalDate.of(2010, 2, 26));
+        address1.setValidUntil(LocalDate.of(2021, 1, 16));
+
+        CanonicalAddress address2 = new CanonicalAddress();
+        address2.setPostalCode("WF3 3SE");
+        address2.setAddressCountry("FR");
+        address2.setValidFrom(LocalDate.of(2021, 1, 16));
+        address2.setValidUntil(LocalDate.of(2021, 8, 2));
+
+        CanonicalAddress address3 = new CanonicalAddress();
+        address3.setPostalCode("WF1 2LZ");
+        address3.setValidFrom(LocalDate.of(2021, 8, 2));
+
+        addresses.add(address1);
+        addresses.add(address2);
+        addresses.add(address3);
+
+        addressService.setAddressCountryIfMissing(addresses);
+
+        MatcherAssert.assertThat(address1.getAddressCountry(), equalTo("GB"));
+        MatcherAssert.assertThat(address2.getAddressCountry(), equalTo("FR"));
+        MatcherAssert.assertThat(address3.getAddressCountry(), equalTo("GB"));
     }
 
     @Test


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Address entries that are retrieved from the OS Data API are manually set to have a country of `GB`, but this logic was not applied to the Manual address entry.

This PR fixes that.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1776](https://govukverify.atlassian.net/browse/OJ-1776)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-1776]: https://govukverify.atlassian.net/browse/OJ-1776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ